### PR TITLE
Feature: Add Apache-2.0 to smart contracts

### DIFF
--- a/src/extensions/ERC20Factory/ERC20Factory.sol
+++ b/src/extensions/ERC20Factory/ERC20Factory.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {MinimalProxyFactory} from "@solidstate/contracts/factory/MinimalProxyFactory.sol";

--- a/src/extensions/ERC20Factory/ERC20FactoryInternal.sol
+++ b/src/extensions/ERC20Factory/ERC20FactoryInternal.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {ERC20FactoryStorage} from "./ERC20FactoryStorage.sol";

--- a/src/extensions/ERC20Factory/ERC20FactoryStorage.sol
+++ b/src/extensions/ERC20Factory/ERC20FactoryStorage.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 library ERC20FactoryStorage {

--- a/src/extensions/ERC20Factory/IERC20Factory.sol
+++ b/src/extensions/ERC20Factory/IERC20Factory.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 interface IERC20Factory {

--- a/src/extensions/ERC721Factory/ERC721Factory.sol
+++ b/src/extensions/ERC721Factory/ERC721Factory.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {MinimalProxyFactory} from "@solidstate/contracts/factory/MinimalProxyFactory.sol";

--- a/src/extensions/ERC721Factory/ERC721FactoryInternal.sol
+++ b/src/extensions/ERC721Factory/ERC721FactoryInternal.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {ERC721FactoryStorage} from "./ERC721FactoryStorage.sol";

--- a/src/extensions/ERC721Factory/ERC721FactoryStorage.sol
+++ b/src/extensions/ERC721Factory/ERC721FactoryStorage.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 library ERC721FactoryStorage {

--- a/src/extensions/ERC721Factory/IERC721Factory.sol
+++ b/src/extensions/ERC721Factory/IERC721Factory.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 interface IERC721Factory {

--- a/src/extensions/ERC721LazyDrop/ERC721LazyDrop.sol
+++ b/src/extensions/ERC721LazyDrop/ERC721LazyDrop.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {ReentrancyGuard} from "@solidstate/contracts/utils/ReentrancyGuard.sol";

--- a/src/extensions/ERC721LazyDrop/ERC721LazyDropInternal.sol
+++ b/src/extensions/ERC721LazyDrop/ERC721LazyDropInternal.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {IERC721LazyDrop} from "./IERC721LazyDrop.sol";

--- a/src/extensions/ERC721LazyDrop/ERC721LazyDropStorage.sol
+++ b/src/extensions/ERC721LazyDrop/ERC721LazyDropStorage.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 library ERC721LazyDropStorage {

--- a/src/extensions/ERC721LazyDrop/ICompatibleERC721.sol
+++ b/src/extensions/ERC721LazyDrop/ICompatibleERC721.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 interface ICompatibleERC721 {

--- a/src/extensions/ERC721LazyDrop/IERC721LazyDrop.sol
+++ b/src/extensions/ERC721LazyDrop/IERC721LazyDrop.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {ERC721LazyDropStorage} from "./ERC721LazyDropStorage.sol";

--- a/src/extensions/applicationFee/ApplicationFee.sol
+++ b/src/extensions/applicationFee/ApplicationFee.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {IApplicationFee} from "./IApplicationFee.sol";

--- a/src/extensions/applicationFee/ApplicationFeeInternal.sol
+++ b/src/extensions/applicationFee/ApplicationFeeInternal.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {IERC20, SafeERC20} from "@solidstate/contracts/utils/SafeERC20.sol";

--- a/src/extensions/applicationFee/ApplicationFeeMock.sol
+++ b/src/extensions/applicationFee/ApplicationFeeMock.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {ApplicationFee, IApplicationFee} from "./ApplicationFee.sol";

--- a/src/extensions/applicationFee/ApplicationFeeStorage.sol
+++ b/src/extensions/applicationFee/ApplicationFeeStorage.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 library ApplicationFeeStorage {

--- a/src/extensions/applicationFee/IApplicationFee.sol
+++ b/src/extensions/applicationFee/IApplicationFee.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 interface IApplicationFee {

--- a/src/extensions/batchMintMetadata/BatchMintMetadata.sol
+++ b/src/extensions/batchMintMetadata/BatchMintMetadata.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {IBatchMintMetadata} from "./IBatchMintMetadata.sol";

--- a/src/extensions/batchMintMetadata/BatchMintMetadataInternal.sol
+++ b/src/extensions/batchMintMetadata/BatchMintMetadataInternal.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {IBatchMintMetadata} from "./IBatchMintMetadata.sol";

--- a/src/extensions/batchMintMetadata/BatchMintMetadataStorage.sol
+++ b/src/extensions/batchMintMetadata/BatchMintMetadataStorage.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 /**

--- a/src/extensions/batchMintMetadata/IBatchMintMetadata.sol
+++ b/src/extensions/batchMintMetadata/IBatchMintMetadata.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 interface IBatchMintMetadata {

--- a/src/extensions/contractMetadata/ContractMetadata.sol
+++ b/src/extensions/contractMetadata/ContractMetadata.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {IContractMetadata} from "./IContractMetadata.sol";

--- a/src/extensions/contractMetadata/ContractMetadataInternal.sol
+++ b/src/extensions/contractMetadata/ContractMetadataInternal.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {IContractMetadata} from "./IContractMetadata.sol";

--- a/src/extensions/contractMetadata/ContractMetadataStorage.sol
+++ b/src/extensions/contractMetadata/ContractMetadataStorage.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 /**

--- a/src/extensions/contractMetadata/IContractMetadata.sol
+++ b/src/extensions/contractMetadata/IContractMetadata.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 /**

--- a/src/extensions/defaultOperatorFilterer/DefaultOperatorFilterer.sol
+++ b/src/extensions/defaultOperatorFilterer/DefaultOperatorFilterer.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {DefaultOperatorFiltererInternal} from "./DefaultOperatorFiltererInternal.sol";

--- a/src/extensions/defaultOperatorFilterer/DefaultOperatorFiltererConstants.sol
+++ b/src/extensions/defaultOperatorFilterer/DefaultOperatorFiltererConstants.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {IOperatorFilterRegistry} from "../../interface/IOperatorFilterRegistry.sol";

--- a/src/extensions/defaultOperatorFilterer/DefaultOperatorFiltererInternal.sol
+++ b/src/extensions/defaultOperatorFilterer/DefaultOperatorFiltererInternal.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {IDefaultOperatorFilterer} from "./IDefaultOperatorFilterer.sol";

--- a/src/extensions/defaultOperatorFilterer/IDefaultOperatorFilterer.sol
+++ b/src/extensions/defaultOperatorFilterer/IDefaultOperatorFilterer.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 interface IDefaultOperatorFilterer {

--- a/src/extensions/global/Global.sol
+++ b/src/extensions/global/Global.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {GlobalInternal} from "./GlobalInternal.sol";

--- a/src/extensions/global/GlobalInternal.sol
+++ b/src/extensions/global/GlobalInternal.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {Globals} from "../../globals/Globals.sol";

--- a/src/extensions/global/GlobalStorage.sol
+++ b/src/extensions/global/GlobalStorage.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 library GlobalStorage {

--- a/src/extensions/initializable/IInitializable.sol
+++ b/src/extensions/initializable/IInitializable.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 interface IInitializable {

--- a/src/extensions/initializable/Initializable.sol
+++ b/src/extensions/initializable/Initializable.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {InitializableInternal} from "./InitializableInternal.sol";

--- a/src/extensions/initializable/InitializableInternal.sol
+++ b/src/extensions/initializable/InitializableInternal.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {InitializableStorage} from "./InitializableStorage.sol";

--- a/src/extensions/initializable/InitializableStorage.sol
+++ b/src/extensions/initializable/InitializableStorage.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 library InitializableStorage {

--- a/src/extensions/lazyMint/ILazyMint.sol
+++ b/src/extensions/lazyMint/ILazyMint.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 /**

--- a/src/extensions/lazyMint/LazyMint.sol
+++ b/src/extensions/lazyMint/LazyMint.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {ILazyMint} from "./ILazyMint.sol";

--- a/src/extensions/lazyMint/LazyMintInternal.sol
+++ b/src/extensions/lazyMint/LazyMintInternal.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {LazyMintStorage} from "./LazyMintStorage.sol";

--- a/src/extensions/lazyMint/LazyMintMock.sol
+++ b/src/extensions/lazyMint/LazyMintMock.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {ILazyMint} from "./ILazyMint.sol";

--- a/src/extensions/lazyMint/LazyMintStorage.sol
+++ b/src/extensions/lazyMint/LazyMintStorage.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 library LazyMintStorage {

--- a/src/extensions/mintMetadata/MintMetadata.sol
+++ b/src/extensions/mintMetadata/MintMetadata.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {MintMetadataInternal} from "./MintMetadataInternal.sol";

--- a/src/extensions/mintMetadata/MintMetadataInternal.sol
+++ b/src/extensions/mintMetadata/MintMetadataInternal.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {MintMetadataStorage} from "./MintMetadataStorage.sol";

--- a/src/extensions/mintMetadata/MintMetadataStorage.sol
+++ b/src/extensions/mintMetadata/MintMetadataStorage.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 library MintMetadataStorage {

--- a/src/extensions/platformFee/IPlatformFee.sol
+++ b/src/extensions/platformFee/IPlatformFee.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 interface IPlatformFee {

--- a/src/extensions/platformFee/PlatformFee.sol
+++ b/src/extensions/platformFee/PlatformFee.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {IPlatformFee} from "./IPlatformFee.sol";

--- a/src/extensions/platformFee/PlatformFeeInternal.sol
+++ b/src/extensions/platformFee/PlatformFeeInternal.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {Global} from "../global/Global.sol";

--- a/src/extensions/royalty/IRoyalty.sol
+++ b/src/extensions/royalty/IRoyalty.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {IERC2981} from "@solidstate/contracts/interfaces/IERC2981.sol";

--- a/src/extensions/royalty/Royalty.sol
+++ b/src/extensions/royalty/Royalty.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {IRoyalty} from "./IRoyalty.sol";

--- a/src/extensions/royalty/RoyaltyInternal.sol
+++ b/src/extensions/royalty/RoyaltyInternal.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {IRoyalty} from "./IRoyalty.sol";

--- a/src/extensions/royalty/RoyaltyStorage.sol
+++ b/src/extensions/royalty/RoyaltyStorage.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 library RoyaltyStorage {

--- a/src/facet/ERC20FactoryFacet.sol
+++ b/src/facet/ERC20FactoryFacet.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {Ownable} from "@solidstate/contracts/access/ownable/Ownable.sol";

--- a/src/facet/ERC721FactoryFacet.sol
+++ b/src/facet/ERC721FactoryFacet.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {Ownable} from "@solidstate/contracts/access/ownable/Ownable.sol";

--- a/src/facet/ERC721LazyDropFacet.sol
+++ b/src/facet/ERC721LazyDropFacet.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {ERC721LazyDrop, IERC721LazyDrop} from "src/extensions/ERC721LazyDrop/ERC721LazyDrop.sol";

--- a/src/facet/SettingsFacet.sol
+++ b/src/facet/SettingsFacet.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {SafeOwnable} from "@solidstate/contracts/access/ownable/SafeOwnable.sol";

--- a/src/factory/Factory.sol
+++ b/src/factory/Factory.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {Ownable} from "@solidstate/contracts/access/ownable/Ownable.sol";

--- a/src/factory/IFactory.sol
+++ b/src/factory/IFactory.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 interface IFactory {

--- a/src/globals/Globals.sol
+++ b/src/globals/Globals.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {Ownable} from "@solidstate/contracts/access/ownable/Ownable.sol";

--- a/src/proxy/Proxy.sol
+++ b/src/proxy/Proxy.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {IDiamondReadable} from "@solidstate/contracts/proxy/diamond/readable/IDiamondReadable.sol";

--- a/src/proxy/ProxyMock.sol
+++ b/src/proxy/ProxyMock.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {Proxy} from "./Proxy.sol";

--- a/src/proxy/readable/Readable.sol
+++ b/src/proxy/readable/Readable.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {IDiamondReadable} from "@solidstate/contracts/proxy/diamond/readable/IDiamondReadable.sol";

--- a/src/proxy/readable/ReadableInternal.sol
+++ b/src/proxy/readable/ReadableInternal.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {IDiamondReadable} from "@solidstate/contracts/proxy/diamond/readable/IDiamondReadable.sol";

--- a/src/proxy/readable/ReadableStorage.sol
+++ b/src/proxy/readable/ReadableStorage.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 /**

--- a/src/proxy/upgradable/IUpgradable.sol
+++ b/src/proxy/upgradable/IUpgradable.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 interface IUpgradable {

--- a/src/proxy/upgradable/Upgradable.sol
+++ b/src/proxy/upgradable/Upgradable.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {IUpgradable} from "./IUpgradable.sol";

--- a/src/proxy/upgradable/UpgradableInternal.sol
+++ b/src/proxy/upgradable/UpgradableInternal.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {UpgradableStorage} from "./UpgradableStorage.sol";

--- a/src/proxy/upgradable/UpgradableStorage.sol
+++ b/src/proxy/upgradable/UpgradableStorage.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 library UpgradableStorage {

--- a/src/registry/Registry.sol
+++ b/src/registry/Registry.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {Proxy, IProxy} from "@solidstate/contracts/proxy/Proxy.sol";

--- a/src/registry/RegistryMock.sol
+++ b/src/registry/RegistryMock.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {Registry} from "./Registry.sol";

--- a/src/tokens/ERC20/ERC20Base.sol
+++ b/src/tokens/ERC20/ERC20Base.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {IERC20} from "@solidstate/contracts/interfaces/IERC20.sol";

--- a/src/tokens/ERC20/ERC20BaseMock.sol
+++ b/src/tokens/ERC20/ERC20BaseMock.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {ERC20Base} from "./ERC20Base.sol";

--- a/src/tokens/ERC721/ERC721Base.sol
+++ b/src/tokens/ERC721/ERC721Base.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {IERC165} from "@solidstate/contracts/interfaces/IERC165.sol";

--- a/src/tokens/ERC721/ERC721BaseMock.sol
+++ b/src/tokens/ERC721/ERC721BaseMock.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {ERC721Base} from "./ERC721Base.sol";

--- a/src/tokens/ERC721/ERC721LazyMint.sol
+++ b/src/tokens/ERC721/ERC721LazyMint.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {IERC165} from "@solidstate/contracts/interfaces/IERC165.sol";

--- a/src/tokens/ERC721/ERC721LazyMintMock.sol
+++ b/src/tokens/ERC721/ERC721LazyMintMock.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import {ERC721LazyMint} from "./ERC721LazyMint.sol";

--- a/test/Factory/Factory.sol
+++ b/test/Factory/Factory.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 // The following tests that proxy and registry contracts work together as intended

--- a/test/extensions/ApplicationFee.t.sol
+++ b/test/extensions/ApplicationFee.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import "forge-std/Test.sol";

--- a/test/extensions/LazyMint.t.sol
+++ b/test/extensions/LazyMint.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import "forge-std/Test.sol";

--- a/test/intergration/Factory.sol
+++ b/test/intergration/Factory.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 // The following tests that proxy and registry contracts work together as intended

--- a/test/intergration/Intergration.sol
+++ b/test/intergration/Intergration.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 // The following tests that proxy and registry contracts work together as intended

--- a/test/intergration/TransactionLayer.t.sol
+++ b/test/intergration/TransactionLayer.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 // The following tests the integration of the "transaction layer" of an application.

--- a/test/intergration/extensions/PlatformFee.t.sol
+++ b/test/intergration/extensions/PlatformFee.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 // The following tests that the platform fee extension works as intentended within the ecosystem

--- a/test/intergration/facet/ERC20FactoryFacet.t.sol
+++ b/test/intergration/facet/ERC20FactoryFacet.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 // The following tests that the platform fee extension works as intentended within the ecosystem

--- a/test/intergration/facet/ERC721FactoryFacet.t.sol
+++ b/test/intergration/facet/ERC721FactoryFacet.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 // The following tests that the platform fee extension works as intended within the ecosystem

--- a/test/intergration/facet/ERC721LazyDrop.t.sol
+++ b/test/intergration/facet/ERC721LazyDrop.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 // The following tests that the settings facet works as intentioned within the open format contracts

--- a/test/intergration/facet/SettingsFacet.t.sol
+++ b/test/intergration/facet/SettingsFacet.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 // The following tests that the settings facet works as intentioned within the open format contracts

--- a/test/proxy/Proxy.t.sol
+++ b/test/proxy/Proxy.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import "forge-std/Test.sol";

--- a/test/registry/Registry.t.sol
+++ b/test/registry/Registry.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import "forge-std/Test.sol";

--- a/test/tokens/ERC20/ERC20Base.t.sol
+++ b/test/tokens/ERC20/ERC20Base.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import "forge-std/Test.sol";

--- a/test/tokens/ERC721/ERC721Base.t.sol
+++ b/test/tokens/ERC721/ERC721Base.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import "forge-std/Test.sol";

--- a/test/tokens/ERC721/ERC721LazyMint.t.sol
+++ b/test/tokens/ERC721/ERC721LazyMint.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.16;
 
 import "forge-std/Test.sol";


### PR DESCRIPTION
This PR changes the SPDX-License-Identifier to Apache-2.0 on all smart contracts until we decide what license we're going to use.