### PR TITLE
Fix: add creatorAccess selectors to settingFacet deploy script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,8 @@ deploy-ERC721FactoryFacet:; forge script scripts/facet/ERC721FactoryFacet.s.sol:
 deploy-ERC20FactoryFacet:; forge script scripts/facet/ERC20FactoryFacet.s.sol:Deploy --rpc-url $(rpc) --broadcast $(verbose) $(legacy) $(slow)
 deploy-ERC721LazyDropFacet:; forge script scripts/facet/ERC721LazyDropFacet.s.sol:Deploy --rpc-url $(rpc) --broadcast $(verbose) $(legacy) $(slow)
 
+# patch
+patch-SettingsFacet:; forge script scripts/facet/SettingsFacet.s.sol:Patch --rpc-url $(rpc) --broadcast $(verbose) $(legacy) $(slow)
 
 # helpers
 

--- a/scripts/facet/SettingsFacet.s.sol
+++ b/scripts/facet/SettingsFacet.s.sol
@@ -42,3 +42,28 @@ contract Deploy is Script, Utils {
         exportContractDeployment(CONTRACT_NAME, address(settingsFacet), block.number);
     }
 }
+
+// creatorAccess - patch - 0x021d69f0e5032a924fdb0efa0b962dc6140038d4a82cee7de0b344deb1337086
+contract Patch is Script, Utils {
+    function run() external {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        vm.startBroadcast(deployerPrivateKey);
+        // deploy
+        SettingsFacet settingsFacet = SettingsFacet(getContractDeploymentAddress(CONTRACT_NAME));
+
+        // construct array of function selectors
+        bytes4[] memory selectors = new bytes4[](2);
+        selectors[0] = settingsFacet.setCreatorAccess.selector;
+        selectors[1] = settingsFacet.hasCreatorAccess.selector;
+
+        // construct and ADD facet cut
+        IDiamondWritableInternal.FacetCut[] memory cuts = new IDiamondWritableInternal.FacetCut[](1);
+        cuts[0] = IDiamondWritableInternal.FacetCut(
+            address(settingsFacet), IDiamondWritableInternal.FacetCutAction.ADD, selectors
+        );
+
+        // add to registry
+        RegistryMock(payable(getContractDeploymentAddress("Registry"))).diamondCut(cuts, address(0), "");
+        vm.stopBroadcast();
+    }
+}


### PR DESCRIPTION
<!--
Before creating a pull request:

- Please update the name of the PR to `[TYPE]: [NAME]` e.g `Feature: Registration form`.
- Please add at least two reviewers.
- Please add yourself as an assignee.
- Please add the correct label to your PR.
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Updating the settingFacets script to include createAccess selectors

<!-- Why are these changes necessary? -->

**Why**: so the SDK can use the createAccess functionality

<!-- How were these changes implemented? -->

**How**: adding `setCreatorAccess` and `hasCreatorAccess` selectors to cut. 

@george-e-d-g-e does this need tests?

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Code complete
- [x] Branch name conforms to [these](https://dev.to/varbsan/a-simplified-convention-for-naming-branches-and-commits-in-git-il4) standards
- [x] Slither passing
- [x] Tests
- [x] Spelling mistakes and console.logs
- [x] Only necessary files changes committed <!-- Please check you haven't committed any unnecessary files. New folders and files may need to be added to .gitignore. -->
- [x] Commenting <!-- To help your future self and other developers please leave appropriate function and helper comments in the code -->
- [ ] Changeset <!-- Run `yarn changeset` to create a changeset -->

<!-- key points/stats that would be useful for marketing purposes -->

**Marketing Nuggets**:

<!-- feel free to add additional comments -->
