### PR TITLE
Feature: Add end timestamp to claim conditions

### DIFF
--- a/.changeset/kind-wombats-perform.md
+++ b/.changeset/kind-wombats-perform.md
@@ -1,0 +1,5 @@
+---
+"@openformat/contracts": patch
+---
+
+Adds endTimestamp to the ERC721LazyDrop claimConditions

--- a/src/extensions/ERC721LazyDrop/ERC721LazyDrop.sol
+++ b/src/extensions/ERC721LazyDrop/ERC721LazyDrop.sol
@@ -126,6 +126,7 @@ abstract contract ERC721LazyDrop is IERC721LazyDrop, ERC721LazyDropInternal, Ree
             _tokenContract,
             ERC721LazyDropStorage.ClaimCondition({
                 startTimestamp: _condition.startTimestamp,
+                endTimestamp: _condition.endTimestamp,
                 maxClaimableSupply: _condition.maxClaimableSupply,
                 supplyClaimed: supplyClaimedAlready,
                 quantityLimitPerWallet: _condition.quantityLimitPerWallet,

--- a/src/extensions/ERC721LazyDrop/ERC721LazyDropInternal.sol
+++ b/src/extensions/ERC721LazyDrop/ERC721LazyDropInternal.sol
@@ -75,6 +75,10 @@ abstract contract ERC721LazyDropInternal is IERC721LazyDrop {
         if (claimCondition.startTimestamp > block.timestamp) {
             revert ERC721LazyDrop_cantClaimYet();
         }
+
+        if (claimCondition.endTimestamp < block.timestamp) {
+            revert ERC721LazyDrop_claimPeriodEnded();
+        }
     }
 
     /**

--- a/src/extensions/ERC721LazyDrop/ERC721LazyDropStorage.sol
+++ b/src/extensions/ERC721LazyDrop/ERC721LazyDropStorage.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.16;
 library ERC721LazyDropStorage {
     struct ClaimCondition {
         uint256 startTimestamp;
+        uint256 endTimestamp;
         uint256 supplyClaimed;
         uint256 maxClaimableSupply;
         uint256 quantityLimitPerWallet;

--- a/src/extensions/ERC721LazyDrop/IERC721LazyDrop.sol
+++ b/src/extensions/ERC721LazyDrop/IERC721LazyDrop.sol
@@ -10,6 +10,7 @@ interface IERC721LazyDrop {
     error ERC721LazyDrop_quantityZeroOrExceededWalletLimit();
     error ERC721LazyDrop_exceededMaxSupply();
     error ERC721LazyDrop_cantClaimYet();
+    error ERC721LazyDrop_claimPeriodEnded();
 
     event ClaimConditionUpdated(
         address tokenContract, ERC721LazyDropStorage.ClaimCondition condition, bool resetEligibility


### PR DESCRIPTION
<!--
Before going any further:

- Please update the name of the PR to `[TYPE]: [NAME]` e.g `Feature: Registration form`.
- Please add yourself as an assignee.
- Please add the correct label to your PR.


-->

Thank you for contributing to Open Format! Please follow this template to ensure a smooth pull request process. Make sure you have read and followed the guidelines in CONTRIBUTING.md before submitting your pull request.

## Summary

This PR adds `end_timestamp` to the claim condition struct for the LazyDrop contracts.

## Description

The claim conditions already include a `start_timestamp`. Adding an `end_timestamp` is beneficial for time restricted events. 

## Type of Change

Please check the boxes that apply to your pull request:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (changes to documentation only)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Testing
I've added a `test_reverts_after_end_timestamp` to`ERC721LazyDrop.t.sol`

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) document
- [x] I have followed the project's [style guide](CONTRIBUTING.md#style-guide)
- [x] I have added or updated tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings or errors
- [ ] I have made corresponding changes to the documentation
- [x] I have checked that my changes do not introduce any new security vulnerabilities
- [x] I have provided a clear and concise description of my changes
- [ ] I have linked to the related issue or bounty, if applicable

## Additional Information

<!-- If you have any additional information or comments related to your pull request, please include them here -->

---

Once again, thank you for your contribution! We appreciate your effort and dedication to improving the Open Format.
