### PR TITLE
Fix: Only return batchUri when calling tokenURI function

### DIFF
--- a/.changeset/popular-berries-push.md
+++ b/.changeset/popular-berries-push.md
@@ -1,0 +1,5 @@
+---
+"@openformat/contracts": patch
+---
+
+Fix: Only return batchUri when calling tokenURI function on ERC721Base

--- a/src/tokens/ERC721/ERC721Base.sol
+++ b/src/tokens/ERC721/ERC721Base.sol
@@ -116,7 +116,7 @@ contract ERC721Base is
 
         // tokenURI was stored using batchMintTo
         string memory batchUri = _getBaseURI(_tokenId);
-        return string.concat(batchUri, UintUtils.toString(_tokenId));
+        return batchUri;
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/tokens/ERC721/ERC721Base.t.sol
+++ b/test/tokens/ERC721/ERC721Base.t.sol
@@ -145,13 +145,13 @@ contract ERC721Base__batchMintTo is Setup {
         assertEq(other, erc721Base.ownerOf(2));
     }
 
-    function test_appends_token_id_to_baseURI() public {
+    function test_returns_baseURI() public {
         vm.prank(creator);
         erc721Base.batchMintTo(other, 3, baseURI);
 
-        assertEq(erc721Base.tokenURI(0), string.concat(baseURI, "0"));
-        assertEq(erc721Base.tokenURI(1), string.concat(baseURI, "1"));
-        assertEq(erc721Base.tokenURI(2), string.concat(baseURI, "2"));
+        assertEq(erc721Base.tokenURI(0), baseURI);
+        assertEq(erc721Base.tokenURI(1), baseURI);
+        assertEq(erc721Base.tokenURI(2), baseURI);
     }
 
     function test_can_be_mixed_with_mintTo() public {
@@ -162,8 +162,8 @@ contract ERC721Base__batchMintTo is Setup {
         erc721Base.batchMintTo(other, 2, baseURI);
 
         assertEq(erc721Base.tokenURI(0), tokenURI);
-        assertEq(erc721Base.tokenURI(1), string.concat(baseURI, "1"));
-        assertEq(erc721Base.tokenURI(2), string.concat(baseURI, "2"));
+        assertEq(erc721Base.tokenURI(1), baseURI);
+        assertEq(erc721Base.tokenURI(2), baseURI);
     }
 
     function test_reverts_if_not_authorised() public {


### PR DESCRIPTION
Closes #112 

## Description
This PR updates the `tokenURI` function in `ERC721Base` to only return the `batchUri` when using `batchMint` functionality.

