### PR TITLE
Feature: add updated base uri event to badge contract

### DIFF
--- a/.changeset/late-lizards-sleep.md
+++ b/.changeset/late-lizards-sleep.md
@@ -1,0 +1,5 @@
+---
+"@openformat/contracts": patch
+---
+
+add metadata update events to ERC721Badge contract

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,19 @@ createERC721Base:; forge script scripts/facet/ERC721FactoryFacet.s.sol:CreateBas
 # Note: make sure app is setup with correct permissions and APP_ID env is set.
 createERC721Badge:; forge script scripts/facet/ERC721FactoryFacet.s.sol:CreateBadge --rpc-url $(rpc) --broadcast $(verbose) $(legacy) $(slow)
 
+# example: make ERC721Badge.mintTo args="0xaf4c80136581212185f37c5e8809120d8fbf6224"
+ERC721Badge.mintTo:; forge script \
+	scripts/tokens/ERC721Badge.s.sol:MintTo \
+	--sig "run(address)" \
+ 	--rpc-url $(rpc) --broadcast $(verbose) $(legacy) $(slow) $(args)
+
+# example: make ERC721Badge.setBaseURI args="0xaf4c80136581212185f37c5e8809120d8fbf6224 someotherurl"
+ERC721Badge.setBaseURI:; forge script \
+	scripts/tokens/ERC721Badge.s.sol:SetBaseURI \
+	--sig "run(address,string)" \
+ 	--rpc-url $(rpc) --broadcast $(verbose) $(legacy) $(slow) \
+	$(word 1, $(args)) $(word 2, $(args))
+
 # Run all update scripts
 update:; make \
 	update-ERC721FactoryFacet \

--- a/scripts/tokens/ERC721Badge.s.sol
+++ b/scripts/tokens/ERC721Badge.s.sol
@@ -25,3 +25,29 @@ contract Deploy is Script, Utils {
         exportContractDeployment(CONTRACT_NAME, address(erc721Badge), block.number);
     }
 }
+
+contract SetBaseURI is Script, Utils {
+    function run(address _contractAddress, string memory _baseURIForTokens) external {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        address deployerAddress = vm.addr(deployerPrivateKey);
+        vm.startBroadcast(deployerPrivateKey);
+
+        ERC721Badge erc721Badge = ERC721Badge(_contractAddress);
+        erc721Badge.setBaseURI(_baseURIForTokens);
+
+        vm.stopBroadcast();
+    }
+}
+
+contract MintTo is Script, Utils {
+    function run(address _contractAddress) external {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        address deployerAddress = vm.addr(deployerPrivateKey);
+        vm.startBroadcast(deployerPrivateKey);
+
+        ERC721Badge erc721Badge = ERC721Badge(_contractAddress);
+        erc721Badge.mintTo(deployerAddress);
+
+        vm.stopBroadcast();
+    }
+}

--- a/src/tokens/ERC721/ERC721Badge.sol
+++ b/src/tokens/ERC721/ERC721Badge.sol
@@ -46,6 +46,8 @@ contract ERC721Badge is
 
     event Minted(address to, string tokenURI);
     event BatchMinted(address to, uint256 quantity, string baseURI);
+    event UpdatedBaseURI(string baseURIForTokens);
+    event BatchMetadataUpdate(uint256 fromTokenId, uint256 toTokenId);
 
     /**
      * @dev this contract is meant to be an implementation for a factory contract
@@ -103,6 +105,8 @@ contract ERC721Badge is
 
         if (bytes(baseURIForTokens).length > 0) {
             _batchMintMetadata(0, MAX_INT, baseURIForTokens);
+            emit BatchMetadataUpdate(0, MAX_INT);
+            emit UpdatedBaseURI(baseURIForTokens);
         }
     }
 
@@ -154,6 +158,9 @@ contract ERC721Badge is
         } else {
             _batchMintMetadata(0, MAX_INT, _baseURIForTokens);
         }
+
+        emit BatchMetadataUpdate(0, MAX_INT);
+        emit UpdatedBaseURI(_baseURIForTokens);
 
         _payPlatformFee(platformFeeRecipient, platformFeeAmount);
     }

--- a/test/tokens/ERC721/ERC721Badge.t.sol
+++ b/test/tokens/ERC721/ERC721Badge.t.sol
@@ -11,6 +11,9 @@ import {IBatchMintMetadata} from "src/extensions/batchMintMetadata/IBatchMintMet
 uint256 constant MAX_INT = 2 ** 256 - 1;
 
 contract Setup is Test {
+    event UpdatedBaseURI(string baseURIForTokens);
+    event BatchMetadataUpdate(uint256 fromTokenId, uint256 toTokenId);
+
     address creator = address(0x10);
     address other = address(0x11);
     address globals = address(0x12);
@@ -62,6 +65,17 @@ contract ERC721Badge_initialise is Setup {
         emptyString.mintTo(creator);
     }
 
+    function test_emits_updated_base_uri_event() public {
+        // global and minter address but baseTokenURI is an empty string
+        bytes memory data = abi.encode(address(0), address(0), baseURI);
+
+        vm.expectEmit(true, true, true, true);
+        emit UpdatedBaseURI(baseURI);
+
+        vm.prank(creator);
+        new ERC721BadgeMock("Name", "Symbol", creator, uint16(tenPercentBPS), data);
+    }
+
     function test_should_revert_when_initialised_without_base_token_URI() public {
         vm.prank(creator);
         // global and minter address but no baseTokenURI in data
@@ -93,6 +107,14 @@ contract ERC721Badge__setBaseURI is Setup {
 
         assertEq(baseURI, erc721Badge.tokenURI(0));
         assertEq(baseURI, erc721Badge.tokenURI(MAX_INT - 1));
+    }
+
+    function test_emits_updated_base_uri_event() public {
+        vm.expectEmit(true, true, true, true);
+        emit UpdatedBaseURI(differentBaseURI);
+
+        vm.prank(creator);
+        erc721Badge.setBaseURI(differentBaseURI);
     }
 
     function test_reverts_when_access_is_invalid() public {


### PR DESCRIPTION
## Summary

adds events to the `ERC721badge` contract to simplify indexing on the subgraph.
adds scripts to run mintTo and setBaseURI on a deployed ERC721badege contract to simplify manual local testing

## Description

While looking at issue OF-99 I ran into difficulty indexing when the baseURIForTokens was updated. This will greatly simplify the process. 

As a bonus the BatchMetaUpdate event will trigger metadata updates on opensea.

## Related Issue/Bounty

Link to the related issue or bounty on GitHub.

makes progress on issue OF-99

## Type of Change

Please check the boxes that apply to your pull request:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (changes to documentation only)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Testing

Please describe the tests you've added or updated to cover your changes, and provide instructions on how to run the tests.

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) document
- [x] I have followed the project's [style guide](CONTRIBUTING.md#style-guide)
- [x] I have added or updated tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings or errors
- [x] I have made corresponding changes to the documentation
- [x] I have checked that my changes do not introduce any new security vulnerabilities
- [x] I have provided a clear and concise description of my changes
- [x] I have linked to the related issue or bounty, if applicable

