### PR TITLE
Feature/OF-209 add contract staging deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,6 @@ POLYGON_RPC_URL=
 
 # Used in scripts that engage with a particular app. An App ID can be generated at https://apps.openformat.tech/
 APP_ID=
+
+# configures deployment scripts to use addresses in a seperate staging file e.g deployments/31337-staging.json
+IS_STAGING=false

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,4 @@ docs/
 node_modules/
 
 # local anvil deployments
-deployed/31337.json
+deployed/31337*

--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,18 @@ RewardsFacet.batchMintBadge:; forge script \
 	--sig "run(address)" \
  	--rpc-url $(rpc) --broadcast $(verbose) $(legacy) $(slow) $(args)
 
+# Simulate create new app and issues rewards
+# example: make SimulateAppAndRewards rpc="anvil" args="appName"
+SimulateAppAndRewards:; forge script \
+	scripts/utils/Simulate.s.sol:SimulateAppAndRewards \
+	--sig "run(string)" \
+	--rpc-url $(rpc) \
+	--broadcast \
+	$(legacy) \
+	$(slow) \
+	$(verbose) \
+	`cast --format-bytes32-string $(args)`
+
 # Run all update scripts
 update:; make \
 	update-ERC721FactoryFacet \

--- a/deployed/421614-staging.json
+++ b/deployed/421614-staging.json
@@ -1,0 +1,69 @@
+{
+  "AppFactory": {
+    "address": "0x4174a9206A2213926fb74bA067Ea00e3E0EBEdbB",
+    "startBlock": 53181340
+  },
+  "ERC20Base": {
+    "address": "0x6F36f7A3CD912F284bc13f85ee04c57Da14319c1",
+    "startBlock": 53181398
+  },
+  "ERC20FactoryFacet": {
+    "address": "0x2C227862Be6F0B1A6fd398E0630A60C09B34A077",
+    "startBlock": 53195102
+  },
+  "ERC721Badge": {
+    "address": "0x9f5c73BffCD63c5e9d1ADf18aAc9D6F6695EAe70",
+    "startBlock": 53194358
+  },
+  "ERC721Base": {
+    "address": "0xC4d53838f4D54f1A44116b3109BfA1bf064a8301",
+    "startBlock": 53193947
+  },
+  "ERC721FactoryFacet": {
+    "address": "0x9147Deb9D788e86b98757a16269a9d033974BfA3",
+    "startBlock": 53194675
+  },
+  "ERC721LazyDropFacet": {
+    "address": "0x24FEdc64981C3ccD789AF7e695e3070Dc7006389",
+    "startBlock": 53195338
+  },
+  "ERC721LazyMint": {
+    "address": "0x937bb2985eE71F62360E9c3AB88B54822Af248a3",
+    "startBlock": 53194310
+  },
+  "Globals": {
+    "address": "0x58d82389CaedB0323660D98F2CadE93D365a38a3",
+    "startBlock": 53180821
+  },
+  "Proxy": {
+    "address": "0x560cd99485820DEb7514ff9b9fBbe1b201c76Af4",
+    "startBlock": 53210918
+  },
+  "Registry": {
+    "address": "0x11cd7aB1B36674a1f41BD19Bbc9e15EaAaF9857F",
+    "startBlock": 53180881
+  },
+  "RewardFacet": {
+    "address": "0xDEc4CaD610B79a0c6e5D3530E6e45662ba6D0f3c",
+    "startBlock": 53194440
+  },
+  "SettingsFacet": {
+    "address": "0xe0aaaf2A2F05DbE1feDa6aA6336fF2533D079BF0",
+    "startBlock": 53194585
+  },
+  "doNotRemoveUsedToParseFile": [
+    "Globals",
+    "Registry",
+    "Proxy",
+    "AppFactory",
+    "ERC20Base",
+    "ERC721Base",
+    "ERC721LazyMint",
+    "ERC721Badge",
+    "RewardFacet",
+    "SettingsFacet",
+    "ERC721FactoryFacet",
+    "ERC20FactoryFacet",
+    "ERC721LazyDropFacet"
+  ]
+}

--- a/scripts/utils/Simulate.s.sol
+++ b/scripts/utils/Simulate.s.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.16;
+
+import "forge-std/Script.sol";
+import "forge-std/console.sol";
+import {Utils} from "scripts/utils/Utils.sol";
+import {AppFactory} from "src/factories/App.sol";
+import {ERC20FactoryFacet} from "src/facet/ERC20FactoryFacet.sol";
+import {ERC721FactoryFacet} from "src/facet/ERC721FactoryFacet.sol";
+import {RewardsFacet} from "src/facet/RewardsFacet.sol";
+
+contract SimulateAppAndRewards is Script, Utils {
+    function run(string memory appName) external {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        address deployerAddress = vm.addr(deployerPrivateKey);
+        vm.startBroadcast(deployerPrivateKey);
+
+        bytes32 appNameBytes32 = vm.parseBytes32(appName);
+
+        if (appNameBytes32.length == 0) {
+            revert("please provide an app name, make CreateApp args=appName");
+        }
+
+        address app =
+          AppFactory(getContractDeploymentAddress("AppFactory")).create(appNameBytes32, deployerAddress);
+
+        //  create token
+        address xp =
+          ERC20FactoryFacet(app).createERC20("XP", "XP", 18, 1000, "Base");
+
+        //  create badge
+        address badge =
+          ERC721FactoryFacet(app).createERC721WithTokenURI(
+            "Novice Forager",
+            "Novice Forager",
+            "TokenURI",
+            deployerAddress,
+            1000,
+            "Badge"
+          );
+
+        //  reward badge, reward token
+        RewardsFacet(app).mintERC20(xp, deployerAddress, 100, "collected berry", "ACTION", "");
+        RewardsFacet(app).mintBadge(badge, deployerAddress, "collected 10 berries", "MISSION", "");
+
+        vm.stopBroadcast();
+
+        console.log("App:", appName);
+        console.log("App Address:", app);
+        console.log("XP Address:", xp);
+        console.log("Badge Address:", badge);
+        console.log("XP balance:", xp);
+        console.log("Badge balance:", badge);
+    }
+}

--- a/scripts/utils/Utils.sol
+++ b/scripts/utils/Utils.sol
@@ -71,7 +71,9 @@ contract Utils is Script {
 
     function _getDeployedFilePath() internal view returns (string memory) {
         string memory inputDir = string.concat(vm.projectRoot(), "/deployed/");
-        string memory file = string.concat(vm.toString(block.chainid), ".json");
+        string memory file = isStaging() ?
+            string.concat(vm.toString(block.chainid), "-staging.json") :
+            string.concat(vm.toString(block.chainid), ".json");
 
         return string.concat(inputDir, file);
     }
@@ -81,6 +83,14 @@ contract Utils is Script {
             return result;
         } catch {
             return "";
+        }
+    }
+
+    function isStaging () internal view returns (bool) {
+        try vm.envBool("IS_STAGING") returns (bool value) {
+            return value;
+        } catch {
+            return false;
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds staging environment for contracts on arbitrum sepolia
adds a simulation script to quickly reward XP and a badge so there is stuff to index for subgraph

## Description

By using an env variable `IS_STAGING=true` you can now use scripts to interact with staging contracts 

Note: ERC721 `Base` and `LazyMint` contracts that are deployed to staging are from #129 

## Related Issue/Bounty

[OF-209](https://linear.app/openformat/issue/OF-209/add-contract-staging-deployment)

## Type of Change

Please check the boxes that apply to your pull request:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (changes to documentation only)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Testing

you can test using anvil and setting the env variable `IS_STAGING=true`.
running `make deploy` will create new deployment file `deployments/31337-staging.json`
