### PR TITLE
Feature/of 282 deploy an erc20 token to act as oft on testnet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,10 +63,10 @@ ops-setup:; make \
 	confirm-operations-wallet \
 	ops-CreateOpenFormatApp \
 	ops-DeployXP \
-	ops-DeployOFT \
+	ops-DeployOFT
 
 ops-CreateOpenFormatApp:; forge script scripts/operations/OpenFormatApp.s.sol:CreateApp --rpc-url $(rpc) --broadcast $(verbose) $(legacy) $(slow)
-ops-DeployOFT:; forge script scripts/operations/OpenFormatApp.s.sol:DeployXP --rpc-url $(rpc) --broadcast $(verbose) $(legacy) $(slow)
+ops-DeployXP:; forge script scripts/operations/OpenFormatApp.s.sol:DeployXP --rpc-url $(rpc) --broadcast $(verbose) $(legacy) $(slow)
 ops-DeployOFT:; forge script scripts/operations/OpenFormatApp.s.sol:DeployOFT --rpc-url $(rpc) --broadcast $(verbose) $(legacy) $(slow)
 
 # helpers

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,16 @@ deploy-ERC721LazyDropFacet:; forge script scripts/facet/ERC721LazyDropFacet.s.so
 # patch
 patch-SettingsFacet:; forge script scripts/facet/SettingsFacet.s.sol:Patch --rpc-url $(rpc) --broadcast $(verbose) $(legacy) $(slow)
 
+# Operations
+# All things relating to Open Formats app and $OFT
+ops-setup:; make \
+	confirm-operations-wallet \
+	ops-CreateOpenFormatApp \
+	ops-DeployOFT \
+
+ops-CreateOpenFormatApp:; forge script scripts/operations/OpenFormatApp.s.sol:CreateApp --rpc-url $(rpc) --broadcast $(verbose) $(legacy) $(slow)
+ops-DeployOFT:; forge script scripts/operations/OpenFormatApp.s.sol:DeployOFT --rpc-url $(rpc) --broadcast $(verbose) $(legacy) $(slow)
+
 # helpers
 
 # example: `make CreateApp args="app name" rpc=anvil`
@@ -186,3 +196,7 @@ update-addPlatformFeeToTokens:; make \
 # Date: 30.03.23
 
 update-SettingsFacet-ExposeGlobals:; forge script scripts/facet/SettingsFacet.s.sol:Update_ExposeGlobals --rpc-url $(rpc) --broadcast $(verbose) $(legacy) $(slow)
+
+# utils - bash scripts
+confirm-operations-wallet:; export WALLET_ADDRESS=$$(cast wallet address ${PRIVATE_KEY}) && \
+	bash bin/confirm-operations-wallet.sh

--- a/Makefile
+++ b/Makefile
@@ -62,9 +62,11 @@ patch-SettingsFacet:; forge script scripts/facet/SettingsFacet.s.sol:Patch --rpc
 ops-setup:; make \
 	confirm-operations-wallet \
 	ops-CreateOpenFormatApp \
+	ops-DeployXP \
 	ops-DeployOFT \
 
 ops-CreateOpenFormatApp:; forge script scripts/operations/OpenFormatApp.s.sol:CreateApp --rpc-url $(rpc) --broadcast $(verbose) $(legacy) $(slow)
+ops-DeployOFT:; forge script scripts/operations/OpenFormatApp.s.sol:DeployXP --rpc-url $(rpc) --broadcast $(verbose) $(legacy) $(slow)
 ops-DeployOFT:; forge script scripts/operations/OpenFormatApp.s.sol:DeployOFT --rpc-url $(rpc) --broadcast $(verbose) $(legacy) $(slow)
 
 # helpers

--- a/bin/confirm-operations-wallet.sh
+++ b/bin/confirm-operations-wallet.sh
@@ -1,0 +1,14 @@
+OPERATIONS_WALLET="0x10CE240074E46579E535506B38A2e6E852c49c8E"
+
+if [ "${WALLET_ADDRESS}" = "${OPERATIONS_WALLET}" ]; then
+  echo "Using operator wallet"
+else
+  echo -e "\nWARNING:\nYou are not using the operations wallet."
+  read -p "Continue? (Y/n): " confirm
+  if [[ "$confirm" =~ ^[Yy]$ ]]; then
+    echo "Continuing..."
+  else
+    echo "Script aborted."
+    exit 1
+  fi
+fi

--- a/scripts/operations/OpenFormatApp.s.sol
+++ b/scripts/operations/OpenFormatApp.s.sol
@@ -10,6 +10,7 @@ import {CONTRACT_NAME as APP_FACTORY} from "scripts/core/AppFactory.s.sol";
 
 string constant OPEN_FORMAT_APP = "Open_Format_App";
 string constant OFT = "OFT";
+string constant XP = "XP";
 
 contract CreateApp is Script, Utils {
     function run() external {
@@ -29,6 +30,34 @@ contract CreateApp is Script, Utils {
         vm.stopBroadcast();
 
         exportContractDeployment(OPEN_FORMAT_APP, openFormatApp, block.number);
+    }
+}
+
+contract DeployXP is Script, Utils {
+    function run() external {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        address deployerAddress = vm.addr(deployerPrivateKey);
+
+        address openFormatApp = getContractDeploymentAddress(OPEN_FORMAT_APP);
+
+        if (openFormatApp == address(0)) {
+           revert("Cannot find open format app, make sure it is created");
+        }
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        // deploy XP
+        address xp = ERC20FactoryFacet(openFormatApp).createERC20(
+          "XP",
+          "XP",
+          18,
+          0,
+          "Base"
+        );
+
+        vm.stopBroadcast();
+
+        exportContractDeployment(XP, xp, block.number);
     }
 }
 

--- a/scripts/operations/OpenFormatApp.s.sol
+++ b/scripts/operations/OpenFormatApp.s.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.16;
+
+import "forge-std/Script.sol";
+import "forge-std/console.sol";
+import {Utils} from "scripts/utils/Utils.sol";
+import {AppFactory} from "src/factories/App.sol";
+import {ERC20FactoryFacet} from "src/facet/ERC20FactoryFacet.sol";
+import {CONTRACT_NAME as APP_FACTORY} from "scripts/core/AppFactory.s.sol";
+
+string constant OPEN_FORMAT_APP = "Open_Format_App";
+string constant OFT = "OFT";
+
+contract CreateApp is Script, Utils {
+    function run() external {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        address deployerAddress = vm.addr(deployerPrivateKey);
+
+        vm.startBroadcast(deployerPrivateKey);
+        address appFactoryAddress = getContractDeploymentAddress(APP_FACTORY);
+
+        if (appFactoryAddress == address(0)) {
+           revert("Cannot find app factory deployment, make sure it is deployed");
+        }
+
+        // create open format app
+        address openFormatApp = AppFactory(appFactoryAddress).create("Open Format App", deployerAddress);
+
+        vm.stopBroadcast();
+
+        exportContractDeployment(OPEN_FORMAT_APP, openFormatApp, block.number);
+    }
+}
+
+contract DeployOFT is Script, Utils {
+    function run() external {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        address deployerAddress = vm.addr(deployerPrivateKey);
+
+        address openFormatApp = getContractDeploymentAddress(OPEN_FORMAT_APP);
+
+        if (openFormatApp == address(0)) {
+           revert("Cannot find open format app, make sure it is created");
+        }
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        // deploy OFT
+        address oft = ERC20FactoryFacet(openFormatApp).createERC20(
+          "Open Format Token",
+          "OFT",
+          18,
+          100_000,
+          "Base"
+        );
+
+        vm.stopBroadcast();
+
+        exportContractDeployment(OFT, oft, block.number);
+    }
+}
+


### PR DESCRIPTION
## Summary

Adds scripts to deploy an Open Format App and Token. 
Scripts store addresses and block number in deployed folder based on network.

Running `make ops-setup` will check if PRIVATE_KEY .env is set to operator wallet address and ask you to confirm before going ahead.

## Notes

No deployment has been made yet.

Do we need to deploy an XP token before running deploying OFT so it works well with subgraph without changing that?
Is 100,000 a good supply for testing now, we can always mint more?

## Related Issue/Bounty

OF-282

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
