### PR TITLE
Feature/of 320 rename credits to tokens in charge facet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,6 +216,11 @@ update-addPlatformFeeToTokens:; make \
 	deploy-ERC721LazyMint \
 	deploy-ERC20Base \
 
+# Rename functions in charge facet on staging contracts
+# Date 30.07.24
+# updates ChargeFacet to rename functions and use token naming convention instead of credits
+update-ChargeFacet_useTokensNamingConvention:; forge script scripts/facet/ChargeFacet.s.sol:Update_useTokensNamingConvention --rpc-url $(rpc) --broadcast $(verbose) $(legacy) $(slow)
+
 # Expose globals
 # deploys a new settings facet, replaces exisitng function selectors and adds new ones
 # Date: 30.03.23

--- a/src/extensions/charge/Charge.sol
+++ b/src/extensions/charge/Charge.sol
@@ -9,57 +9,57 @@ import {IERC2612} from "@solidstate/contracts/token/ERC20/permit/IERC2612.sol";
 abstract contract Charge is ICharge, ChargeInternal {
     /**
      * @notice Charge a user for a specific service.
-     * @dev Transfers the specified `amount` of `credit` tokens from the `user` to the operator.
+     * @dev Transfers the specified `amount` of `tokens` from the `user` to the operator.
      * @param user The address of the user to be charged.
-     * @param credit The address of the ERC20 token used for payment.
+     * @param token The address of the ERC20 token used for payment.
      * @param amount The amount of tokens to be transferred.
      * @param chargeId A unique identifier for the charge.
      * @param chargeType The type of charge.
      */
-    function chargeUser(address user, address credit, uint256 amount, bytes32 chargeId, bytes32 chargeType) external {
+    function chargeUser(address user, address token, uint256 amount, bytes32 chargeId, bytes32 chargeType) external {
         if (msg.sender != _operator()) {
             revert Charge_doNotHavePermission();
         }
 
-        IERC20(credit).transferFrom(user, _operator(), amount);
+        IERC20(token).transferFrom(user, _operator(), amount);
 
-        emit chargedUser(user, credit, amount, chargeId, chargeType);
+        emit ChargedUser(user, token, amount, chargeId, chargeType);
     }
 
     /**
-     * @notice Set the minimum credit balance required for a specific token.
-     * @dev Sets the minimum balance of `credit` tokens that users must maintain.
-     * @param credit The address of the ERC20 token.
-     * @param balance The minimum balance to be set.
+     * @notice Set the required token balance for a specific token.
+     * @dev Sets the required balance of tokens that users must maintain.
+     * @param token The address of the ERC20 token.
+     * @param balance The required balance to be set.
      */
-    function setMinimumCreditBalance(address credit, uint256 balance) external {
+    function setRequiredTokenBalance(address token, uint256 balance) external {
         if (msg.sender != _operator()) {
             revert Charge_doNotHavePermission();
         }
 
-        _setMinimumCreditBalance(credit, balance);
+        _setRequiredTokenBalance(token, balance);
 
-        emit minimumCreditBalanceUpdated(credit, balance);
+        emit RequiredTokenBalanceUpdated(token, balance);
     }
 
     /**
-     * @notice Get the minimum credit balance required for a specific token.
-     * @dev returns the minimum balance of `credit` tokens that users must maintain.
-     * @param credit The address of the ERC20 token.
-     * @return uint256 The set minimum balance.
+     * @notice Get the required token balance for a specific token.
+     * @dev returns the required balance of tokens that users must maintain.
+     * @param token The address of the ERC20 token.
+     * @return uint256 The set required balance.
      */
-    function getMinimumCreditBalance(address credit) external view returns (uint256) {
-        return _getMinimumCreditBalance(credit);
+    function getRequiredTokenBalance(address token) external view returns (uint256) {
+        return _getRequiredTokenBalance(token);
     }
 
     /**
      * @notice Check if a user has sufficient funds.
-     * @dev Returns true if the `user` has at least the minimum credit balance and allowance for the given `credit` token.
+     * @dev Returns true if the `user` has at least the required token balance and allowance for the given ERC20 token.
      * @param user The address of the user.
-     * @param credit The address of the ERC20 token.
-     * @return bool True if the user has sufficient funds and allowance, otherwise false.
+     * @param token The address of the ERC20 token.
+     * @return bool True if the user has sufficient balance and allowance, otherwise false.
      */
-    function hasFunds(address user, address credit) external view returns (bool) {
-        return _hasFunds(user, credit, _getMinimumCreditBalance(credit));
+    function hasFunds(address user, address token) external view returns (bool) {
+        return _hasFunds(user, token, _getRequiredTokenBalance(token));
     }
 }

--- a/src/extensions/charge/ChargeInternal.sol
+++ b/src/extensions/charge/ChargeInternal.sol
@@ -5,19 +5,19 @@ import {ChargeStorage} from "./ChargeStorage.sol";
 import {IERC20, SafeERC20} from "@solidstate/contracts/utils/SafeERC20.sol";
 
 abstract contract ChargeInternal {
-    function _hasFunds(address user, address credit, uint256 minimumBalance) internal view returns (bool) {
+    function _hasFunds(address user, address token, uint256 requiredBalance) internal view returns (bool) {
         return (
-            IERC20(credit).balanceOf(user) >= minimumBalance
-                && IERC20(credit).allowance(user, address(this)) >= minimumBalance
+            IERC20(token).balanceOf(user) >= requiredBalance
+                && IERC20(token).allowance(user, address(this)) >= requiredBalance
         );
     }
 
-    function _getMinimumCreditBalance(address credit) internal view returns (uint256) {
-        return ChargeStorage.layout().minimumCreditBalance[credit];
+    function _getRequiredTokenBalance(address token) internal view returns (uint256) {
+        return ChargeStorage.layout().requiredTokenBalance[token];
     }
 
-    function _setMinimumCreditBalance(address credit, uint256 amount) internal {
-        ChargeStorage.layout().minimumCreditBalance[credit] = amount;
+    function _setRequiredTokenBalance(address token, uint256 amount) internal {
+        ChargeStorage.layout().requiredTokenBalance[token] = amount;
     }
 
     /**

--- a/src/extensions/charge/ChargeStorage.sol
+++ b/src/extensions/charge/ChargeStorage.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.16;
 
 library ChargeStorage {
     struct Layout {
-        mapping(address => uint256) minimumCreditBalance; // credit => minimum balance required to conduct actions.
+        mapping(address => uint256) requiredTokenBalance; // ERC20 token address => required balance.
     }
 
     bytes32 internal constant STORAGE_SLOT = keccak256("openformat.contracts.storage.Charge");

--- a/src/extensions/charge/ICharge.sol
+++ b/src/extensions/charge/ICharge.sol
@@ -4,6 +4,6 @@ pragma solidity ^0.8.16;
 interface ICharge {
     error Charge_doNotHavePermission();
 
-    event minimumCreditBalanceUpdated(address credit, uint256 balance);
-    event chargedUser(address user, address credit, uint256 amount, bytes32 chargeId, bytes32 chargeType);
+    event RequiredTokenBalanceUpdated(address token, uint256 balance);
+    event ChargedUser(address user, address token, uint256 amount, bytes32 chargeId, bytes32 chargeType);
 }

--- a/test/integration/facet/ChargeFacet.t.sol
+++ b/test/integration/facet/ChargeFacet.t.sol
@@ -51,7 +51,7 @@ address constant socialConscious = address(0x13);
 uint256 constant OPERATOR_BALANCE = 0;
 uint256 constant USER_BALANCE = 10;
 uint256 constant CHARGE_AMOUNT = 1;
-uint256 constant MINIMUM_CREDIT_BALANCE = 1;
+uint256 constant REQUIRED_TOKEN_BALANCE = 1;
 uint256 constant USER_APPROVED_SPEND = 5;
 bytes32 constant CHARGE_ID = bytes32("0x123");
 bytes32 constant CHARGE_TYPE = bytes32("TX");
@@ -70,7 +70,7 @@ contract Setup is Test, Helpers {
     ERC20Base erc20Implementation;
     bytes32 erc20ImplementationId;
     ERC20FactoryFacet erc20FactoryFacet;
-    address creditContract;
+    address tokenAddress;
 
     function setUp() public {
         vm.deal(OPERATOR_ADDRESS, 1 ether);
@@ -126,8 +126,8 @@ contract Setup is Test, Helpers {
             bytes4[] memory selectors = new bytes4[](4);
             selectors[0] = chargeFacet.chargeUser.selector;
             selectors[1] = chargeFacet.hasFunds.selector;
-            selectors[2] = chargeFacet.setMinimumCreditBalance.selector;
-            selectors[3] = chargeFacet.getMinimumCreditBalance.selector;
+            selectors[2] = chargeFacet.setRequiredTokenBalance.selector;
+            selectors[3] = chargeFacet.getRequiredTokenBalance.selector;
 
             registry.diamondCut(
                 prepareSingleFacetCut(address(chargeFacet), IDiamondWritableInternal.FacetCutAction.ADD, selectors),
@@ -151,7 +151,7 @@ contract Setup is Test, Helpers {
 
         // use app to create erc20 contract
         vm.prank(OPERATOR_ADDRESS);
-        creditContract = ERC20FactoryFacet(address(app)).createERC20("name", "symbol", 18, 0, erc20ImplementationId);
+        tokenAddress = ERC20FactoryFacet(address(app)).createERC20("name", "symbol", 18, 0, erc20ImplementationId);
 
         _afterSetup();
     }
@@ -163,173 +163,173 @@ contract Setup is Test, Helpers {
 }
 
 contract ChargeFacet__integration_chargeUser is Setup {
-    event chargedUser(address user, address credit, uint256 amount, bytes32 chargeId, bytes32 chargeType);
+    event ChargedUser(address user, address token, uint256 amount, bytes32 chargeId, bytes32 chargeType);
 
     function _afterSetup() internal override {
         // Give user a balance
         vm.prank(OPERATOR_ADDRESS);
-        ERC20Base(creditContract).mintTo(USER_ADDRESS, USER_BALANCE);
-        assertEq(ERC20Base(creditContract).balanceOf(OPERATOR_ADDRESS), OPERATOR_BALANCE);
-        assertEq(ERC20Base(creditContract).balanceOf(USER_ADDRESS), USER_BALANCE);
+        ERC20Base(tokenAddress).mintTo(USER_ADDRESS, USER_BALANCE);
+        assertEq(ERC20Base(tokenAddress).balanceOf(OPERATOR_ADDRESS), OPERATOR_BALANCE);
+        assertEq(ERC20Base(tokenAddress).balanceOf(USER_ADDRESS), USER_BALANCE);
 
         // User approves allowance spend for app
         vm.prank(USER_ADDRESS);
-        ERC20Base(creditContract).approve(address(app), USER_APPROVED_SPEND);
-        assertEq(ERC20Base(creditContract).allowance(USER_ADDRESS, address(app)), USER_APPROVED_SPEND);
+        ERC20Base(tokenAddress).approve(address(app), USER_APPROVED_SPEND);
+        assertEq(ERC20Base(tokenAddress).allowance(USER_ADDRESS, address(app)), USER_APPROVED_SPEND);
     }
 
     function test_operator_charges_user() public {
-        // Operator charges credits
+        // Operator charges tokens
         vm.prank(OPERATOR_ADDRESS);
-        ChargeFacet(address(app)).chargeUser(USER_ADDRESS, creditContract, CHARGE_AMOUNT, CHARGE_ID, CHARGE_TYPE);
+        ChargeFacet(address(app)).chargeUser(USER_ADDRESS, tokenAddress, CHARGE_AMOUNT, CHARGE_ID, CHARGE_TYPE);
 
         // Charge amount is removed from USER_ADDRESS
-        assertEq(ERC20Base(creditContract).balanceOf(USER_ADDRESS), USER_BALANCE - CHARGE_AMOUNT);
-        assertEq(ERC20Base(creditContract).allowance(USER_ADDRESS, address(app)), USER_APPROVED_SPEND - CHARGE_AMOUNT);
+        assertEq(ERC20Base(tokenAddress).balanceOf(USER_ADDRESS), USER_BALANCE - CHARGE_AMOUNT);
+        assertEq(ERC20Base(tokenAddress).allowance(USER_ADDRESS, address(app)), USER_APPROVED_SPEND - CHARGE_AMOUNT);
 
         // Charge amount is added to OPERATOR_ADDRESS
-        assertEq(ERC20Base(creditContract).balanceOf(OPERATOR_ADDRESS), OPERATOR_BALANCE + CHARGE_AMOUNT);
+        assertEq(ERC20Base(tokenAddress).balanceOf(OPERATOR_ADDRESS), OPERATOR_BALANCE + CHARGE_AMOUNT);
     }
 
     function test_emits_charged_user_event() public {
         vm.expectEmit(true, true, true, true, address(app));
-        emit chargedUser(USER_ADDRESS, creditContract, CHARGE_AMOUNT, CHARGE_ID, CHARGE_TYPE);
+        emit ChargedUser(USER_ADDRESS, tokenAddress, CHARGE_AMOUNT, CHARGE_ID, CHARGE_TYPE);
 
-        // Operator charges credits
+        // Operator charges tokens
         vm.prank(OPERATOR_ADDRESS);
-        ChargeFacet(address(app)).chargeUser(USER_ADDRESS, creditContract, CHARGE_AMOUNT, CHARGE_ID, CHARGE_TYPE);
+        ChargeFacet(address(app)).chargeUser(USER_ADDRESS, tokenAddress, CHARGE_AMOUNT, CHARGE_ID, CHARGE_TYPE);
     }
 
     function test_reverts_when_user_has_insufficient_allowance() public {
         // Set user allowance to zero
         vm.prank(USER_ADDRESS);
-        ERC20Base(creditContract).approve(address(app), 0);
-        assertEq(ERC20Base(creditContract).allowance(USER_ADDRESS, address(app)), 0);
+        ERC20Base(tokenAddress).approve(address(app), 0);
+        assertEq(ERC20Base(tokenAddress).allowance(USER_ADDRESS, address(app)), 0);
 
         // Operator fails to charge user
         vm.prank(OPERATOR_ADDRESS);
         vm.expectRevert(IERC20BaseInternal.ERC20Base__InsufficientAllowance.selector);
-        ChargeFacet(address(app)).chargeUser(USER_ADDRESS, creditContract, CHARGE_AMOUNT, CHARGE_ID, CHARGE_TYPE);
+        ChargeFacet(address(app)).chargeUser(USER_ADDRESS, tokenAddress, CHARGE_AMOUNT, CHARGE_ID, CHARGE_TYPE);
     }
 
     function test_reverts_when_user_has_insufficient_balance() public {
         // User transfers funds so balance is 0
         vm.prank(USER_ADDRESS);
-        ERC20Base(creditContract).transfer(OTHER_ADDRESS, USER_BALANCE);
-        assertEq(ERC20Base(creditContract).balanceOf(USER_ADDRESS), 0);
+        ERC20Base(tokenAddress).transfer(OTHER_ADDRESS, USER_BALANCE);
+        assertEq(ERC20Base(tokenAddress).balanceOf(USER_ADDRESS), 0);
 
         // Operator fails to charge user
         vm.prank(OPERATOR_ADDRESS);
         vm.expectRevert(IERC20BaseInternal.ERC20Base__TransferExceedsBalance.selector);
-        ChargeFacet(address(app)).chargeUser(USER_ADDRESS, creditContract, CHARGE_AMOUNT, CHARGE_ID, CHARGE_TYPE);
+        ChargeFacet(address(app)).chargeUser(USER_ADDRESS, tokenAddress, CHARGE_AMOUNT, CHARGE_ID, CHARGE_TYPE);
     }
 
     function test_reverts_when_caller_is_not_operator() public {
         // User approves allowance spend for app
         vm.prank(USER_ADDRESS);
-        ERC20Base(creditContract).approve(address(app), USER_APPROVED_SPEND);
-        assertEq(ERC20Base(creditContract).allowance(USER_ADDRESS, address(app)), USER_APPROVED_SPEND);
+        ERC20Base(tokenAddress).approve(address(app), USER_APPROVED_SPEND);
+        assertEq(ERC20Base(tokenAddress).allowance(USER_ADDRESS, address(app)), USER_APPROVED_SPEND);
 
         // Other fails to charge user
         vm.prank(OTHER_ADDRESS);
         vm.expectRevert(ICharge.Charge_doNotHavePermission.selector);
-        ChargeFacet(address(app)).chargeUser(USER_ADDRESS, creditContract, CHARGE_AMOUNT, CHARGE_ID, CHARGE_TYPE);
+        ChargeFacet(address(app)).chargeUser(USER_ADDRESS, tokenAddress, CHARGE_AMOUNT, CHARGE_ID, CHARGE_TYPE);
     }
 }
 
 contract ChargeFacet__integration_hasFunds is Setup {
     function _afterSetup() internal override {
-        // set minimum credit balance
+        // set required token balance
         vm.prank(OPERATOR_ADDRESS);
-        ChargeFacet(address(app)).setMinimumCreditBalance(creditContract, MINIMUM_CREDIT_BALANCE);
+        ChargeFacet(address(app)).setRequiredTokenBalance(tokenAddress, REQUIRED_TOKEN_BALANCE);
 
         // Give user a balance
         vm.prank(OPERATOR_ADDRESS);
-        ERC20Base(creditContract).mintTo(USER_ADDRESS, USER_BALANCE);
-        assertEq(ERC20Base(creditContract).balanceOf(OPERATOR_ADDRESS), OPERATOR_BALANCE);
-        assertEq(ERC20Base(creditContract).balanceOf(USER_ADDRESS), USER_BALANCE);
+        ERC20Base(tokenAddress).mintTo(USER_ADDRESS, USER_BALANCE);
+        assertEq(ERC20Base(tokenAddress).balanceOf(OPERATOR_ADDRESS), OPERATOR_BALANCE);
+        assertEq(ERC20Base(tokenAddress).balanceOf(USER_ADDRESS), USER_BALANCE);
 
         // User approves allowance spend for app
         vm.prank(USER_ADDRESS);
-        ERC20Base(creditContract).approve(address(app), USER_APPROVED_SPEND);
-        assertEq(ERC20Base(creditContract).allowance(USER_ADDRESS, address(app)), USER_APPROVED_SPEND);
+        ERC20Base(tokenAddress).approve(address(app), USER_APPROVED_SPEND);
+        assertEq(ERC20Base(tokenAddress).allowance(USER_ADDRESS, address(app)), USER_APPROVED_SPEND);
     }
 
     function test_returns_true_when_user_has_sufficient_balance_and_allowance() public {
-        assertTrue(ChargeFacet(address(app)).hasFunds(USER_ADDRESS, creditContract));
+        assertTrue(ChargeFacet(address(app)).hasFunds(USER_ADDRESS, tokenAddress));
     }
 
-    function test_returns_true_when_minimum_credit_balance_is_set_to_zero() public {
-        // Set minimum credit balance to zero
+    function test_returns_true_when_minimum_token_balance_is_set_to_zero() public {
+        // Set minimum token balance to zero
         vm.prank(OPERATOR_ADDRESS);
-        ChargeFacet(address(app)).setMinimumCreditBalance(creditContract, 0);
+        ChargeFacet(address(app)).setRequiredTokenBalance(tokenAddress, 0);
 
-        assertTrue(ChargeFacet(address(app)).hasFunds(OTHER_ADDRESS, creditContract));
+        assertTrue(ChargeFacet(address(app)).hasFunds(OTHER_ADDRESS, tokenAddress));
     }
 
     function test_returns_false_when_user_has_insufficient_balance() public {
         // User transfers funds so balance is 0
         vm.prank(USER_ADDRESS);
-        ERC20Base(creditContract).transfer(OTHER_ADDRESS, USER_BALANCE);
-        assertEq(ERC20Base(creditContract).balanceOf(USER_ADDRESS), 0);
+        ERC20Base(tokenAddress).transfer(OTHER_ADDRESS, USER_BALANCE);
+        assertEq(ERC20Base(tokenAddress).balanceOf(USER_ADDRESS), 0);
 
-        assertFalse(ChargeFacet(address(app)).hasFunds(USER_ADDRESS, creditContract));
+        assertFalse(ChargeFacet(address(app)).hasFunds(USER_ADDRESS, tokenAddress));
     }
 
     function test_returns_false_when_user_has_insufficient_allowance() public {
         // User sets app allowance to 0
         vm.prank(USER_ADDRESS);
-        ERC20Base(creditContract).approve(address(app), 0);
-        assertEq(ERC20Base(creditContract).allowance(USER_ADDRESS, address(app)), 0);
+        ERC20Base(tokenAddress).approve(address(app), 0);
+        assertEq(ERC20Base(tokenAddress).allowance(USER_ADDRESS, address(app)), 0);
 
-        assertFalse(ChargeFacet(address(app)).hasFunds(USER_ADDRESS, creditContract));
+        assertFalse(ChargeFacet(address(app)).hasFunds(USER_ADDRESS, tokenAddress));
     }
 
     function test_returns_false_when_user_has_insufficient_allowance_and_balance() public {
-        assertFalse(ChargeFacet(address(app)).hasFunds(OTHER_ADDRESS, creditContract));
+        assertFalse(ChargeFacet(address(app)).hasFunds(OTHER_ADDRESS, tokenAddress));
     }
 }
 
-contract ChargeFacet__integration_setMinimumCreditBalance is Setup {
-    event minimumCreditBalanceUpdated(address credit, uint256 balance);
+contract ChargeFacet__integration_setRequiredTokenBalance is Setup {
+    event RequiredTokenBalanceUpdated(address token, uint256 balance);
 
-    function test_sets_minimum_credit_balance() public {
+    function test_sets_minimum_token_balance() public {
         vm.prank(OPERATOR_ADDRESS);
-        ChargeFacet(address(app)).setMinimumCreditBalance(creditContract, MINIMUM_CREDIT_BALANCE);
+        ChargeFacet(address(app)).setRequiredTokenBalance(tokenAddress, REQUIRED_TOKEN_BALANCE);
 
-        assertEq(ChargeFacet(address(app)).getMinimumCreditBalance(creditContract), MINIMUM_CREDIT_BALANCE);
+        assertEq(ChargeFacet(address(app)).getRequiredTokenBalance(tokenAddress), REQUIRED_TOKEN_BALANCE);
     }
 
-    function test_emits_minimum_credit_balance_updated_event() public {
+    function test_emits_minimum_token_balance_updated_event() public {
         vm.expectEmit(true, true, true, true, address(app));
-        emit minimumCreditBalanceUpdated(creditContract, MINIMUM_CREDIT_BALANCE);
+        emit RequiredTokenBalanceUpdated(tokenAddress, REQUIRED_TOKEN_BALANCE);
 
         vm.prank(OPERATOR_ADDRESS);
-        ChargeFacet(address(app)).setMinimumCreditBalance(creditContract, MINIMUM_CREDIT_BALANCE);
+        ChargeFacet(address(app)).setRequiredTokenBalance(tokenAddress, REQUIRED_TOKEN_BALANCE);
     }
 
     function test_reverts_when_caller_is_not_the_operator() public {
         vm.expectRevert(ICharge.Charge_doNotHavePermission.selector);
 
         vm.prank(OTHER_ADDRESS);
-        ChargeFacet(address(app)).setMinimumCreditBalance(creditContract, MINIMUM_CREDIT_BALANCE);
+        ChargeFacet(address(app)).setRequiredTokenBalance(tokenAddress, REQUIRED_TOKEN_BALANCE);
     }
 }
 
 contract ChargeFacet__integration_multicall is Setup {
-    event chargedUser(address user, address credit, uint256 amount, bytes32 chargeId, bytes32 chargeType);
+    event ChargedUser(address user, address token, uint256 amount, bytes32 chargeId, bytes32 chargeType);
 
     function _afterSetup() internal override {
         // Give user a balance
         vm.prank(OPERATOR_ADDRESS);
-        ERC20Base(creditContract).mintTo(USER_ADDRESS, USER_BALANCE);
-        assertEq(ERC20Base(creditContract).balanceOf(OPERATOR_ADDRESS), OPERATOR_BALANCE);
-        assertEq(ERC20Base(creditContract).balanceOf(USER_ADDRESS), USER_BALANCE);
+        ERC20Base(tokenAddress).mintTo(USER_ADDRESS, USER_BALANCE);
+        assertEq(ERC20Base(tokenAddress).balanceOf(OPERATOR_ADDRESS), OPERATOR_BALANCE);
+        assertEq(ERC20Base(tokenAddress).balanceOf(USER_ADDRESS), USER_BALANCE);
 
         // User approves allowance spend for app
         vm.prank(USER_ADDRESS);
-        ERC20Base(creditContract).approve(address(app), USER_APPROVED_SPEND);
-        assertEq(ERC20Base(creditContract).allowance(USER_ADDRESS, address(app)), USER_APPROVED_SPEND);
+        ERC20Base(tokenAddress).approve(address(app), USER_APPROVED_SPEND);
+        assertEq(ERC20Base(tokenAddress).allowance(USER_ADDRESS, address(app)), USER_APPROVED_SPEND);
     }
 
     function test_charges_users_with_multicall() public {
@@ -341,26 +341,26 @@ contract ChargeFacet__integration_multicall is Setup {
         for (uint256 i = 0; i < numberOfCharges; i++) {
             calls[i] = abi.encodeCall(
                 ChargeFacet(address(app)).chargeUser,
-                (USER_ADDRESS, creditContract, CHARGE_AMOUNT, bytes32(i), CHARGE_TYPE)
+                (USER_ADDRESS, tokenAddress, CHARGE_AMOUNT, bytes32(i), CHARGE_TYPE)
             );
         }
 
         // expect emits to match number of charges
         vm.expectEmit(true, true, true, true, address(app));
         for (uint256 i = 0; i < numberOfCharges; i++) {
-            emit chargedUser(USER_ADDRESS, creditContract, CHARGE_AMOUNT, bytes32(i), CHARGE_TYPE);
+            emit ChargedUser(USER_ADDRESS, tokenAddress, CHARGE_AMOUNT, bytes32(i), CHARGE_TYPE);
         }
 
         vm.prank(OPERATOR_ADDRESS);
         RewardsFacet(address(app)).multicall(calls);
 
         // Charge amount is removed from USER_ADDRESS
-        assertEq(ERC20Base(creditContract).balanceOf(USER_ADDRESS), USER_BALANCE - totalAmountCharged);
+        assertEq(ERC20Base(tokenAddress).balanceOf(USER_ADDRESS), USER_BALANCE - totalAmountCharged);
         assertEq(
-            ERC20Base(creditContract).allowance(USER_ADDRESS, address(app)), USER_APPROVED_SPEND - totalAmountCharged
+            ERC20Base(tokenAddress).allowance(USER_ADDRESS, address(app)), USER_APPROVED_SPEND - totalAmountCharged
         );
 
         // Charge amount is added to OPERATOR_ADDRESS
-        assertEq(ERC20Base(creditContract).balanceOf(OPERATOR_ADDRESS), OPERATOR_BALANCE + totalAmountCharged);
+        assertEq(ERC20Base(tokenAddress).balanceOf(OPERATOR_ADDRESS), OPERATOR_BALANCE + totalAmountCharged);
     }
 }


### PR DESCRIPTION
## Summary

- Renames functions to use `token` instead of `credits` and improve clarity
- Uses Pascal case for event names
- Updates ChargeFacet deployment scripts
- Adds a deployment script to update staging contracts from previous implementation

## Description

See [OF-319](https://linear.app/openformat/issue/OF-319/is-credits-naming-convention-correct-on-contracts-and-subgraph) for reasoning. TLDR; it is confusing to use `credits` on a contract and subgraph level with the existing codebase.

## Related Issue/Bounty

[OF-320](https://linear.app/openformat/issue/OF-320/rename-credits-to-tokens-in-charge-facet)

## Type of Change

ChargeFacet is currently only deployed to staging so no breaking changes will result from this PR

- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)

## Testing

Tests and comments have been updated to reflect renaming


## Notes
I will deploy to staging after PR review
