### PR TITLE
Feature/of 321 deploy updated charge facet to staging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ update-addPlatformFeeToTokens:; make \
 	deploy-ERC20Base \
 
 # Rename functions in charge facet on staging contracts
-# Date 30.07.24
+# Date 31.07.24 (Executed on arbitrum-sepolia-staging contracts)
 # updates ChargeFacet to rename functions and use token naming convention instead of credits
 update-ChargeFacet_useTokensNamingConvention:; forge script scripts/facet/ChargeFacet.s.sol:Update_useTokensNamingConvention --rpc-url $(rpc) --broadcast $(verbose) $(legacy) $(slow)
 

--- a/deployed/421614-staging.json
+++ b/deployed/421614-staging.json
@@ -4,8 +4,8 @@
     "startBlock": 53181340
   },
   "ChargeFacet": {
-    "address": "0xcb80fE226bf533fdda8c19D0Aa9Be36124eAA5a5",
-    "startBlock": 66291305
+    "address": "0x87d62B44557F731c5B9D93fbBa096928Fb382799",
+    "startBlock": 67933710
   },
   "ERC20Base": {
     "address": "0x6F36f7A3CD912F284bc13f85ee04c57Da14319c1",


### PR DESCRIPTION
Performed the update script `update-ChargeFacet_useTokensNamingConvention` on the arbitrum-sepolia-staging` contracts

- Updates deployment address of charge facet
- Records date and environment update script was run in make file