### PR TITLE
Feature/of 335 anyone can reward from the contract

### DIFF
--- a/src/facet/RewardsFacet.sol
+++ b/src/facet/RewardsFacet.sol
@@ -52,6 +52,10 @@ contract RewardsFacet is Multicall, SafeOwnable {
         bytes32 _activityType,
         string calldata _uri
     ) public {
+        if (msg.sender != _operator()) {
+            revert RewardsFacet_NotAuthorized();
+        }
+
         if (!_canMint(_token)) {
             revert RewardsFacet_NotAuthorized();
         }
@@ -68,6 +72,10 @@ contract RewardsFacet is Multicall, SafeOwnable {
         bytes32 _activityType,
         string calldata _uri
     ) public {
+        if (msg.sender != _operator()) {
+            revert RewardsFacet_NotAuthorized();
+        }
+
         Token(_token).transferFrom(msg.sender, _to, _amount);
         emit TokenTransferred(_token, _to, _amount, _id, _activityType, _uri);
     }
@@ -92,6 +100,10 @@ contract RewardsFacet is Multicall, SafeOwnable {
         bytes32 _activityType,
         bytes calldata _data
     ) public {
+        if (msg.sender != _operator()) {
+            revert RewardsFacet_NotAuthorized();
+        }
+
         if (!_canMint(_badgeContract)) {
             revert RewardsFacet_NotAuthorized();
         }
@@ -118,6 +130,10 @@ contract RewardsFacet is Multicall, SafeOwnable {
         bytes32 _activityType,
         bytes calldata _data
     ) public {
+        if (msg.sender != _operator()) {
+            revert RewardsFacet_NotAuthorized();
+        }
+
         if (!_canMint(_badgeContract)) {
             revert RewardsFacet_NotAuthorized();
         }
@@ -135,6 +151,10 @@ contract RewardsFacet is Multicall, SafeOwnable {
         bytes32 _activityType,
         string calldata _uri
     ) public {
+        if (msg.sender != _operator()) {
+            revert RewardsFacet_NotAuthorized();
+        }
+
         if (!_canMint(_token)) {
             revert RewardsFacet_NotAuthorized();
         }
@@ -150,8 +170,16 @@ contract RewardsFacet is Multicall, SafeOwnable {
         bytes32 _activityType,
         string calldata _uri
     ) public {
+        if (msg.sender != _operator()) {
+            revert RewardsFacet_NotAuthorized();
+        }
+
         NFT(_token).transferFrom(msg.sender, _to, _tokenId);
         emit BadgeTransferred(_token, _to, _tokenId, _id, _activityType, _uri);
+    }
+
+    function _operator() internal virtual returns (address) {
+        return _owner();
     }
 
     function _canMint(address _token) internal virtual returns (bool) {

--- a/test/integration/facet/RewardsFacet.t.sol
+++ b/test/integration/facet/RewardsFacet.t.sol
@@ -85,6 +85,7 @@ contract Setup is Test, Helpers {
     // ipfs uri taken from https://docs.ipfs.tech/how-to/best-practices-for-nft-data/#types-of-ipfs-links-and-when-to-use-them
     string baseURI = "ipfs://bafybeibnsoufr2renqzsh347nrx54wcubt5lgkeivez63xvivplfwhtpym/";
     uint16 tenPercentBPS = 1000;
+    uint256 oneEther = 1 ether;
 
     event ERC721Minted(address token, uint256 quantity, address to, bytes32 id, bytes32 activityType, string uri);
     event BadgeMinted(
@@ -97,7 +98,7 @@ contract Setup is Test, Helpers {
         other = address(0x11);
         socialConscious = address(0x12);
 
-        vm.deal(creator, 1 ether);
+        vm.deal(creator, oneEther);
 
         // deploy contracts
         globals = new Globals();
@@ -223,6 +224,15 @@ contract RewardFacet__integration_mintBadge is Setup {
         vm.prank(creator);
         RewardsFacet(address(app)).mintBadge(badgeContract, other, activityId, activityType, abi.encode("testing 123"));
     }
+
+    function test_reverts_when_caller_is_not_the_app_operator() public {
+        vm.prank(creator);
+        ERC721Badge(badgeContract).grantRole(MINTER_ROLE, other);
+
+        vm.prank(other);
+        vm.expectRevert();
+        RewardsFacet(address(app)).mintBadge(badgeContract, other, activityId, activityType, "");
+    }
 }
 
 contract RewardFacet__integration_batchMintBadge is Setup {
@@ -265,6 +275,15 @@ contract RewardFacet__integration_batchMintBadge is Setup {
         vm.expectRevert();
         RewardsFacet(address(app)).batchMintBadge(badgeContract, other, 10, activityId, activityType, "");
         vm.stopPrank();
+    }
+
+    function test_reverts_when_caller_is_not_the_app_operator() public {
+        vm.prank(creator);
+        ERC721Badge(badgeContract).grantRole(MINTER_ROLE, other);
+
+        vm.prank(other);
+        vm.expectRevert();
+        RewardsFacet(address(app)).batchMintBadge(badgeContract, other, 10, activityId, activityType, "");
     }
 }
 

--- a/test/integration/facet/RewardsFacet.t.sol
+++ b/test/integration/facet/RewardsFacet.t.sol
@@ -18,6 +18,7 @@ import {RegistryMock} from "src/registry/RegistryMock.sol";
 import {AppFactory} from "src/factories/App.sol";
 import {Globals} from "src/globals/Globals.sol";
 
+import {ERC721Base} from "src/tokens/ERC721/ERC721Base.sol";
 import {ERC721Badge} from "src/tokens/ERC721/ERC721Badge.sol";
 import {IERC721Factory} from "@extensions/ERC721Factory/IERC721Factory.sol";
 import {ERC721FactoryFacet} from "src/facet/ERC721FactoryFacet.sol";
@@ -68,16 +69,16 @@ contract Setup is Test, Helpers {
     SettingsFacet settingsFacet;
     RewardsFacet rewardsFacet;
 
-    ERC721Badge erc721Implementation;
+    ERC721Base erc721Implementation;
     bytes32 erc721ImplementationId;
+    ERC721Badge badgeImplementation;
+    bytes32 badgeImplementationId;
     ERC721FactoryFacet erc721FactoryFacet;
 
     ERC20Base erc20Implementation;
     bytes32 erc20ImplementationId;
     ERC20FactoryFacet erc20FactoryFacet;
 
-    bytes32 badgeImplementationId = bytes32("Badge");
-    address badgeContract;
     string name = "Name";
     string symbol = "Symbol";
     bytes32 activityId = "collected a berry";
@@ -87,10 +88,11 @@ contract Setup is Test, Helpers {
     uint16 tenPercentBPS = 1000;
     uint256 oneEther = 1 ether;
 
+    event TokenMinted(address token, address to, uint256 amount, bytes32 id, bytes32 activityType, string uri);
+    event TokenTransferred(address token, address to, uint256 amount, bytes32 id, bytes32 activityType, string uri);
     event ERC721Minted(address token, uint256 quantity, address to, bytes32 id, bytes32 activityType, string uri);
-    event BadgeMinted(
-        address token, uint256 quantity, address to, bytes32 activityId, bytes32 activityType, bytes data
-    );
+    event BadgeMinted(address token, uint256 quantity, address to, bytes32 activityId, bytes32 activityType, bytes data);
+    event BadgeTransferred(address token, address to, uint256 tokenId, bytes32 id, bytes32 activityType, string uri);
 
     function setUp() public {
         // assign addresses
@@ -106,8 +108,10 @@ contract Setup is Test, Helpers {
         appImplementation = new Proxy(true);
         appFactory = new AppFactory(address(appImplementation), address(registry), address(globals));
 
-        erc721Implementation = new ERC721Badge(false);
-        erc721ImplementationId = bytes32("Badge");
+        erc721Implementation = new ERC721Base();
+        erc721ImplementationId = bytes32("Base");
+        badgeImplementation = new ERC721Badge(false);
+        badgeImplementationId = bytes32("Badge");
         erc721FactoryFacet = new ERC721FactoryFacet();
 
         erc20Implementation = new ERC20Base();
@@ -120,6 +124,7 @@ contract Setup is Test, Helpers {
 
         // setup globals
         globals.setPlatformFee(0, 0, socialConscious);
+        globals.setERC721Implementation(badgeImplementationId, address(badgeImplementation));
         globals.setERC721Implementation(erc721ImplementationId, address(erc721Implementation));
         globals.setERC20Implementation(erc20ImplementationId, address(erc20Implementation));
 
@@ -186,12 +191,6 @@ contract Setup is Test, Helpers {
             );
         }
 
-        // use app to create badge contract
-        vm.prank(creator);
-        badgeContract = ERC721FactoryFacet(address(app)).createERC721WithTokenURI(
-            name, symbol, baseURI, creator, uint16(tenPercentBPS), badgeImplementationId
-        );
-
         _afterSetup();
     }
 
@@ -202,6 +201,16 @@ contract Setup is Test, Helpers {
 }
 
 contract RewardFacet__integration_mintBadge is Setup {
+    address badgeContract;
+
+    function _afterSetup() internal override {
+        // use app to create badge contract
+        vm.prank(creator);
+        badgeContract = ERC721FactoryFacet(address(app)).createERC721WithTokenURI(
+            name, symbol, baseURI, creator, uint16(tenPercentBPS), badgeImplementationId
+        );
+    }
+
     function test_rewards_badge() public {
         vm.prank(creator);
         RewardsFacet(address(app)).mintBadge(badgeContract, other, activityId, activityType, "");
@@ -230,12 +239,22 @@ contract RewardFacet__integration_mintBadge is Setup {
         ERC721Badge(badgeContract).grantRole(MINTER_ROLE, other);
 
         vm.prank(other);
-        vm.expectRevert();
+        vm.expectRevert(RewardsFacet.RewardsFacet_NotAuthorized.selector);
         RewardsFacet(address(app)).mintBadge(badgeContract, other, activityId, activityType, "");
     }
 }
 
 contract RewardFacet__integration_batchMintBadge is Setup {
+    address badgeContract;
+
+    function _afterSetup() internal override {
+        // use app to create badge contract
+        vm.prank(creator);
+        badgeContract = ERC721FactoryFacet(address(app)).createERC721WithTokenURI(
+            name, symbol, baseURI, creator, uint16(tenPercentBPS), badgeImplementationId
+        );
+    }
+
     function test_rewards_multiple_badges() public {
         vm.prank(creator);
         RewardsFacet(address(app)).batchMintBadge(badgeContract, other, 10, activityId, activityType, "");
@@ -261,18 +280,11 @@ contract RewardFacet__integration_batchMintBadge is Setup {
         );
     }
 
-    function test_reverts_when_sender_not_authorised() public {
-        vm.expectRevert(RewardsFacet.RewardsFacet_NotAuthorized.selector);
-
-        vm.prank(other);
-        RewardsFacet(address(app)).batchMintBadge(badgeContract, other, 10, activityId, activityType, "");
-    }
-
-    function test_reverts_when_app_not_granted_minter_role() public {
+    function test_reverts_when_app_is_not_granted_minter_role() public {
         vm.startPrank(creator);
         ERC721Badge(badgeContract).revokeRole(MINTER_ROLE, address(app));
 
-        vm.expectRevert();
+        vm.expectRevert(ERC721Badge.ERC721Badge_notAuthorized.selector);
         RewardsFacet(address(app)).batchMintBadge(badgeContract, other, 10, activityId, activityType, "");
         vm.stopPrank();
     }
@@ -282,12 +294,125 @@ contract RewardFacet__integration_batchMintBadge is Setup {
         ERC721Badge(badgeContract).grantRole(MINTER_ROLE, other);
 
         vm.prank(other);
-        vm.expectRevert();
+        vm.expectRevert(RewardsFacet.RewardsFacet_NotAuthorized.selector);
         RewardsFacet(address(app)).batchMintBadge(badgeContract, other, 10, activityId, activityType, "");
     }
 }
 
+contract RewardFacet__integration_mintERC721 is Setup {
+    address baseContract;
+
+    function _afterSetup() internal override {
+        // use app to create badge contract
+        vm.prank(creator);
+        baseContract = ERC721FactoryFacet(address(app)).createERC721(
+            name, symbol, creator, uint16(tenPercentBPS), erc721ImplementationId
+        );
+    }
+
+    function test_rewards_multiple_badges() public {
+        vm.prank(creator);
+        RewardsFacet(address(app)).mintERC721(baseContract, other, 10, baseURI, activityId, activityType, "");
+
+        assertEq(ERC721Base(baseContract).balanceOf(other), 10);
+    }
+
+    function test_emits_erc721_minted_event() public {
+        vm.expectEmit(true, true, true, true);
+        emit ERC721Minted(baseContract, 10, other, activityId, activityType, "");
+
+        vm.prank(creator);
+        RewardsFacet(address(app)).mintERC721(baseContract, other, 10, baseURI, activityId, activityType, "");
+    }
+
+    function test_reverts_when_app_not_granted_minter_role() public {
+        vm.startPrank(creator);
+        ERC721Base(baseContract).revokeRole(MINTER_ROLE, address(app));
+
+        vm.expectRevert(ERC721Base.ERC721Base_notAuthorized.selector);
+        RewardsFacet(address(app)).mintERC721(baseContract, other, 10, baseURI, activityId, activityType, "");
+        vm.stopPrank();
+    }
+
+    function test_reverts_when_caller_is_not_the_app_operator() public {
+        vm.prank(creator);
+        ERC721Base(baseContract).grantRole(MINTER_ROLE, other);
+
+        vm.prank(other);
+        vm.expectRevert(RewardsFacet.RewardsFacet_NotAuthorized.selector);
+        RewardsFacet(address(app)).mintERC721(baseContract, other, 10, baseURI, activityId, activityType, "");
+    }
+}
+
+contract RewardFacet__integration_transferERC721 is Setup {
+    address baseContract;
+
+    function _afterSetup() internal override {
+        // use app to create badge contract
+        vm.startPrank(creator);
+        baseContract = ERC721FactoryFacet(address(app)).createERC721(
+            name, symbol, creator, uint16(tenPercentBPS), erc721ImplementationId
+        );
+
+        // mint nft to creator and approve app as operator
+        ERC721Base(baseContract).mintTo(creator, baseURI);
+        ERC721Base(baseContract).setApprovalForAll(address(app), true);
+        vm.stopPrank();
+    }
+
+    function test_setup() public {
+        assertEq(ERC721Base(baseContract).ownerOf(0), creator);
+        assertEq(ERC721Base(baseContract).isApprovedOrOwner(address(app), 0), true);
+    }
+
+    function test_transfers_erc721() public {
+        vm.prank(creator);
+        RewardsFacet(address(app)).transferERC721(baseContract, other, 0, activityId, activityType, "");
+
+        assertEq(ERC721Base(baseContract).ownerOf(0), other);
+        assertEq(ERC721Base(baseContract).isApprovedOrOwner(address(app), 0), false);
+    }
+
+    function test_emits_badge_transferred_event() public {
+        vm.expectEmit(true, true, true, true);
+        emit BadgeTransferred(baseContract, other, 0, activityId, activityType, "");
+
+        vm.prank(creator);
+        RewardsFacet(address(app)).transferERC721(baseContract, other, 0, activityId, activityType, "");
+    }
+
+    function test_reverts_when_app_not_approved() public {
+        ERC721Base(baseContract).setApprovalForAll(address(app), false);
+        vm.expectRevert(RewardsFacet.RewardsFacet_NotAuthorized.selector);
+
+        vm.prank(other);
+        RewardsFacet(address(app)).transferERC721(baseContract, other, 0, activityId, activityType, "");
+    }
+
+    function test_reverts_when_caller_is_not_the_app_operator() public {
+        // mint token 2 to other and approve app
+        vm.prank(creator);
+        ERC721Base(baseContract).mintTo(other, baseURI);
+        vm.prank(other);
+        ERC721Base(baseContract).setApprovalForAll(address(app), true);
+
+        vm.prank(other);
+        vm.expectRevert(RewardsFacet.RewardsFacet_NotAuthorized.selector);
+        RewardsFacet(address(app)).transferERC721(baseContract, other, 1, activityId, activityType, "");
+    }
+}
+
 contract RewardFacet__integration_multicall is Setup {
+    address badgeContract;
+
+    function _afterSetup() internal override {
+        // use app to create badge contract
+        vm.prank(creator);
+        badgeContract = ERC721FactoryFacet(address(app)).createERC721WithTokenURI(
+            name, symbol, baseURI, creator, uint16(tenPercentBPS), badgeImplementationId
+        );
+    }
+
     function test_can_multicall_minting_badges() public {
         bytes[] memory calls = new bytes[](2);
         calls[0] =
@@ -305,7 +430,6 @@ contract RewardFacet__integration_multicall is Setup {
 }
 
 contract RewardsFacet__integration_mintERC20 is Setup {
-    event TokenMinted(address token, address to, uint256 amount, bytes32 id, bytes32 activityType, string uri);
     address tokenContract;
 
     function _afterSetup() internal override {
@@ -362,7 +486,7 @@ contract RewardsFacet__integration_mintERC20 is Setup {
         ERC20Base(tokenContract).grantRole(MINTER_ROLE, other);
 
         vm.prank(other);
-        vm.expectRevert();
+        vm.expectRevert(RewardsFacet.RewardsFacet_NotAuthorized.selector);
         RewardsFacet(address(app)).mintERC20(
             tokenContract,
             other,
@@ -381,7 +505,7 @@ contract RewardsFacet__integration_mintERC20 is Setup {
         ERC20Base(tokenContract).revokeRole(ADMIN_ROLE, creator);
 
         vm.prank(other);
-        vm.expectRevert();
+        vm.expectRevert(RewardsFacet.RewardsFacet_NotAuthorized.selector);
         RewardsFacet(address(app)).mintERC20(
             tokenContract,
             other,
@@ -394,8 +518,6 @@ contract RewardsFacet__integration_mintERC20 is Setup {
 }
 
 contract RewardsFacet__integration_transferERC20 is Setup {
-    event TokenTransferred(address token, address to, uint256 amount, bytes32 id, bytes32 activityType, string uri);
-
     address tokenContract;
 
     function _afterSetup() internal override {
@@ -463,7 +585,7 @@ contract RewardsFacet__integration_transferERC20 is Setup {
         ERC20Base(tokenContract).approve(address(app), oneEther);
 
         vm.prank(other);
-        vm.expectRevert();
+        vm.expectRevert(RewardsFacet.RewardsFacet_NotAuthorized.selector);
         RewardsFacet(address(app)).transferERC20(
             tokenContract,
             other,


### PR DESCRIPTION
## Summary

- Fixes security bug on all reward facet functions by only allowing app operators to call them
- Adds missing integration tests for all reward facet functions

Previous tests gave a false impression as where reverting for a different reason. Currently anyone is able to reward on any app given the correct approvals are set up.

Will deploy to staging after review.

## Related Issue/Bounty

[OF-335](https://linear.app/openformat/issue/OF-335/anyone-can-reward-from-the-contract)

## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)

