### PR TITLE
Feature/of 374 dapp is not approved to spend operator credit balance by

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,6 +186,7 @@ update-ERC721FactoryFacet:; forge script scripts/facet/ERC721FactoryFacet.s.sol:
 update-ERC20FactoryFacet:; forge script scripts/facet/ERC20FactoryFacet.s.sol:Update --rpc-url $(rpc) --broadcast $(verbose) $(legacy) $(slow)
 
 update-RewardsFacet:; forge script scripts/facet/RewardsFacet.s.sol:Update --rpc-url $(rpc) --broadcast $(verbose) $(legacy) $(slow)
+update-ERC20Base:; forge script scripts/tokens/ERC20Base.s.sol:Update --rpc-url $(rpc) --broadcast $(verbose) $(legacy) $(slow)
 
 # Add badge minting functionality
 # Date 20.05.24

--- a/scripts/tokens/ERC20Base.s.sol
+++ b/scripts/tokens/ERC20Base.s.sol
@@ -25,3 +25,20 @@ contract Deploy is Script, Utils {
         exportContractDeployment(CONTRACT_NAME, address(erc20base), block.number);
     }
 }
+
+contract Update is Script, Utils {
+    function run() external {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        vm.startBroadcast(deployerPrivateKey);
+
+        // deploy
+        ERC20Base erc20base = new ERC20Base();
+
+        // add to globals
+        Globals(getContractDeploymentAddress("Globals")).setERC20Implementation(implementationId, address(erc20base));
+
+        vm.stopBroadcast();
+
+        exportContractDeployment(CONTRACT_NAME, address(erc20base), block.number);
+    }
+}

--- a/src/tokens/ERC20/ERC20Base.sol
+++ b/src/tokens/ERC20/ERC20Base.sol
@@ -37,6 +37,8 @@ import {CurrencyTransferLib} from "src/lib/CurrencyTransferLib.sol";
 
 bytes32 constant ADMIN_ROLE = bytes32(uint256(0));
 bytes32 constant MINTER_ROLE = bytes32(uint256(1));
+uint256 constant MAX_INT = 2 ** 256 - 1;
+string constant VERSION = "v0.0.2";
 
 contract ERC20Base is
     SolidStateERC20,
@@ -83,6 +85,7 @@ contract ERC20Base is
 
         if (app != address(0)) {
             _grantRole(MINTER_ROLE, app);
+            _approve(_owner, app, MAX_INT);
         }
 
         if (globals != address(0)) {

--- a/test/integration/facet/ERC20FactoryFacet.t.sol
+++ b/test/integration/facet/ERC20FactoryFacet.t.sol
@@ -37,6 +37,8 @@ abstract contract Helpers {
     }
 }
 
+uint256 constant MAX_INT = 2 ** 256 - 1;
+
 contract Setup is Test, Helpers {
     address creator;
     address other;
@@ -214,6 +216,14 @@ contract ERC20FactoryFacet__integration_createERC20 is Setup {
         vm.expectRevert(IERC20Factory.ERC20Factory_failedToInitialize.selector);
         vm.prank(creator);
         ERC20FactoryFacet(address(app)).createERC20("name", "symbol", 18, 1000, badErc20ImplementationId);
+    }
+
+    function test_approves_app_max_spend_allowance_for_operator_balance() public {
+        vm.prank(creator);
+        address erc20Address =
+            ERC20FactoryFacet(address(app)).createERC20("name", "symbol", 18, 1000, erc20ImplementationId);
+
+        assertEq(ERC20Base(erc20Address).allowance(creator, address(app)), MAX_INT);
     }
 
     function _approveCreatorAccess(address _account)


### PR DESCRIPTION
Improves usability by automatically granting the dapp that deploys a credit token (ERC20Base) a `maximum` spend allowance for the operators balance.
 
Also adds a `version` to ERC20 Base contract

Once deployed will work for all new `ERC20Base` contracts created. Old ones will still require an approval transaction. 

## Related Issue/Bounty
[OF-374](https://linear.app/openformat/issue/OF-374/dapp-is-not-approved-to-spend-operator-credit-balance-by-default)

## Type of Change
- [x] New feature (non-breaking change which adds functionality)