### PR TITLE
Freature: Added Points contract

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ deploy:; make \
 	deploy-Proxy \
 	deploy-AppFactory \
 	deploy-ERC20Base \
+	deploy-ERC20Point \
 	deploy-ERC721Base \
 	deploy-ERC721LazyMint \
 	deploy-ERC721Badge \
@@ -47,6 +48,7 @@ deploy-ERC721Base:; forge script scripts/tokens/ERC721Base.s.sol:Deploy --rpc-ur
 deploy-ERC721LazyMint:; forge script scripts/tokens/ERC721LazyMint.s.sol:Deploy --rpc-url $(rpc) --broadcast $(verbose) $(gasPrice) $(legacy) $(slow)
 deploy-ERC721Badge:; forge script scripts/tokens/ERC721Badge.s.sol:Deploy --rpc-url $(rpc) --broadcast $(verbose) $(gasPrice) $(legacy) $(slow)
 deploy-ERC20Base:; forge script scripts/tokens/ERC20Base.s.sol:Deploy --rpc-url $(rpc) --broadcast $(verbose) $(gasPrice) $(legacy) $(slow)
+deploy-ERC20Point:; forge script scripts/tokens/ERC20Point.s.sol:Deploy --rpc-url $(rpc) --broadcast $(verbose) $(gasPrice) $(legacy) $(slow)
 
 # facets
 deploy-ChargeFacet:; forge script scripts/facet/ChargeFacet.s.sol:Deploy --rpc-url $(rpc) --broadcast $(verbose) $(gasPrice) $(legacy) $(slow)

--- a/scripts/tokens/ERC20Point.s.sol
+++ b/scripts/tokens/ERC20Point.s.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.16;
+
+import "forge-std/Script.sol";
+import {Utils} from "scripts/utils/Utils.sol";
+import {ERC20Point} from "src/tokens/ERC20/ERC20Point.sol";
+import {Globals} from "src/globals/Globals.sol";
+
+string constant CONTRACT_NAME = "ERC20Point";
+bytes32 constant implementationId = "Point";
+
+contract Deploy is Script, Utils {
+    function run() external {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        vm.startBroadcast(deployerPrivateKey);
+
+        // deploy
+        ERC20Point erc20point = new ERC20Point();
+
+        // add to globals
+        Globals(getContractDeploymentAddress("Globals")).setERC20Implementation(implementationId, address(erc20point));
+
+        vm.stopBroadcast();
+
+        exportContractDeployment(CONTRACT_NAME, address(erc20point), block.number);
+    }
+}

--- a/scripts/utils/Simulate.s.sol
+++ b/scripts/utils/Simulate.s.sol
@@ -8,6 +8,9 @@ import {AppFactory} from "src/factories/App.sol";
 import {ERC20FactoryFacet} from "src/facet/ERC20FactoryFacet.sol";
 import {ERC721FactoryFacet} from "src/facet/ERC721FactoryFacet.sol";
 import {RewardsFacet} from "src/facet/RewardsFacet.sol";
+import {ERC20Base} from "src/tokens/ERC20/ERC20Base.sol";
+import {ERC20Point} from "src/tokens/ERC20/ERC20Point.sol";
+import {ERC721Badge} from "src/tokens/ERC721/ERC721Badge.sol";
 
 contract SimulateAppAndRewards is Script, Utils {
     function run(string memory appName) external {
@@ -26,7 +29,11 @@ contract SimulateAppAndRewards is Script, Utils {
 
         //  create token
         address xp =
-          ERC20FactoryFacet(app).createERC20("XP", "XP", 18, 1000, "Base");
+          ERC20FactoryFacet(app).createERC20("XP", "XP", 18, 10000000000000000000, "Base");
+
+        //  create Point token
+        address points =
+          ERC20FactoryFacet(app).createERC20("Points", "Points", 18, 10000000000000000000, "Point");
 
         //  create badge
         address badge =
@@ -41,6 +48,7 @@ contract SimulateAppAndRewards is Script, Utils {
 
         //  reward badge, reward token
         RewardsFacet(app).mintERC20(xp, deployerAddress, 100, "collected berry", "ACTION", "");
+        RewardsFacet(app).mintERC20(points, deployerAddress, 100, "collected wood", "ACTION", "");
         RewardsFacet(app).mintBadge(badge, deployerAddress, "collected 10 berries", "MISSION", "");
 
         vm.stopBroadcast();
@@ -48,8 +56,10 @@ contract SimulateAppAndRewards is Script, Utils {
         console.log("App:", appName);
         console.log("App Address:", app);
         console.log("XP Address:", xp);
+        console.log("Point Address:", points);
         console.log("Badge Address:", badge);
-        console.log("XP balance:", xp);
-        console.log("Badge balance:", badge);
+        console.log("XP balance:", ERC20Base(xp).balanceOf(deployerAddress));
+        console.log("Point balance:", ERC20Point(points).balanceOf(deployerAddress));
+        console.log("Badge balance:", ERC721Badge(badge).balanceOf(deployerAddress));
     }
 }

--- a/src/tokens/ERC20/ERC20Point.sol
+++ b/src/tokens/ERC20/ERC20Point.sol
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.16;
+
+import {IERC20} from "@solidstate/contracts/interfaces/IERC20.sol";
+import {SolidStateERC20} from "@solidstate/contracts/token/ERC20/SolidStateERC20.sol";
+import {IERC2612} from "@solidstate/contracts/token/ERC20/permit/IERC2612.sol";
+import {ERC165Base} from "@solidstate/contracts/introspection/ERC165/base/ERC165Base.sol";
+import {IERC165} from "@solidstate/contracts/interfaces/IERC165.sol";
+import {AccessControl} from "@solidstate/contracts/access/access_control/AccessControl.sol";
+import {Multicall} from "@solidstate/contracts/utils/Multicall.sol";
+import {ReentrancyGuard} from "@solidstate/contracts/utils/ReentrancyGuard.sol";
+
+import {ContractMetadata, IContractMetadata} from "@extensions/contractMetadata/ContractMetadata.sol";
+import {Initializable} from "@extensions/initializable/Initializable.sol";
+import {Global} from "@extensions/global/Global.sol";
+import {PlatformFee} from "@extensions/platformFee/PlatformFee.sol";
+
+import {CurrencyTransferLib} from "src/lib/CurrencyTransferLib.sol";
+
+/**
+ *  @dev Thirdweb inspired ERC20Point contract using solidstates ERC20 contract and diamond storage throughout.
+ *       has the edition of ERC165
+ *
+ *  The `ERC20Point` smart contract implements the ERC20 standard, but it is not transferable token.
+ *  It includes the following additions/modifications to standard ERC20 logic:
+ *
+ *      - Ability to mint tokens via the provided `mintTo` function. No `burn` function exists.
+ *
+ *      - Ownership of the contract, with the ability to restrict certain functions to
+ *        only be called by the contract's owner.
+ *
+ *      - Multicall capability to perform multiple actions atomically
+ *
+ *      - All transfer functions revert.
+ */
+
+bytes32 constant ADMIN_ROLE = bytes32(uint256(0));
+bytes32 constant MINTER_ROLE = bytes32(uint256(1));
+
+contract ERC20Point is
+    SolidStateERC20,
+    AccessControl,
+    Multicall,
+    ContractMetadata,
+    Initializable,
+    ERC165Base,
+    Global,
+    PlatformFee,
+    ReentrancyGuard
+{
+    error ERC20Point_notAuthorized();
+    error ERC20Point_zeroAmount();
+    error ERC20Point_nonTransferableToken();
+
+    function initialize(
+        address _owner,
+        string memory _name,
+        string memory _symbol,
+        uint8 _decimals,
+        uint256 _supply,
+        bytes memory _data
+    ) public initializer {
+        _grantRole(ADMIN_ROLE, _owner);
+
+        _setName(_name);
+        _setSymbol(_symbol);
+        _setDecimals(_decimals);
+
+        _mint(_owner, _supply);
+
+        _setSupportsInterface(type(IERC165).interfaceId, true);
+        _setSupportsInterface(type(IERC20).interfaceId, true);
+        _setSupportsInterface(type(IERC2612).interfaceId, true);
+        _setSupportsInterface(type(IContractMetadata).interfaceId, true);
+
+        if (_data.length == 0) {
+            return;
+        }
+
+        // decode data to app address and globals address
+        (address app, address globals) = abi.decode(_data, (address, address));
+
+        if (app != address(0)) {
+            _grantRole(MINTER_ROLE, app);
+        }
+
+        if (globals != address(0)) {
+            _setGlobals(globals);
+        }
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                          Minting logic
+    //////////////////////////////////////////////////////////////*/
+
+    /**
+     *  @notice          Lets an authorized address mint tokens to a recipient.
+     *  @dev             The logic in the `_canMint` function determines whether the caller is authorized to mint tokens.
+     *
+     *  @param _to       The recipient of the tokens to mint.
+     *  @param _amount   Quantity of tokens to mint.
+     */
+    function mintTo(address _to, uint256 _amount) public payable virtual nonReentrant {
+        if (!_canMint()) {
+            revert ERC20Point_notAuthorized();
+        }
+
+        if (_amount < 1) {
+            revert ERC20Point_zeroAmount();
+        }
+
+        (address platformFeeRecipient, uint256 platformFeeAmount) = _checkPlatformFee();
+
+        _mint(_to, _amount);
+
+        _payPlatformFee(platformFeeRecipient, platformFeeAmount);
+    }
+
+    /**
+     *  @notice          Reverts with non transferable error.
+     *  @dev             Caller should own the `_amount` of tokens.
+     *
+     *  @param _amount   The number of tokens to burn.
+     */
+    function burn(uint256 _amount) external virtual {
+        _burn(msg.sender, _amount);
+    }
+
+
+    /*//////////////////////////////////////////////////////////////
+                    Internal (overrideable) functions
+    //////////////////////////////////////////////////////////////*/
+
+    /// @dev Returns whether tokens can be minted in the given execution context.
+    function _canMint() internal view virtual returns (bool) {
+        return _hasRole(ADMIN_ROLE, msg.sender) || _hasRole(MINTER_ROLE, msg.sender);
+    }
+
+    /// @dev Returns whether owner can be set in the given execution context.
+    function _canSetContractURI() internal view virtual override returns (bool) {
+        return _hasRole(ADMIN_ROLE, msg.sender);
+    }
+
+    /// @dev grants minter role if data is just an address
+    function _grantMinterRoleFromData(bytes memory _data) internal virtual {
+        if (_data.length == 0) {
+            return;
+        }
+
+        (address account) = abi.decode(_data, (address));
+        if (account != address(0)) {
+            _grantRole(MINTER_ROLE, account);
+        }
+    }
+
+    /// @dev ERC2612 related, reverts with non transferable error
+    function _permit(address _owner, address _spender, uint256 _amount, uint256 _deadline, uint8 _v, bytes32 _r, bytes32 _s) internal virtual override {
+        revert ERC20Point_nonTransferableToken();
+    }
+
+    /// @dev ERC20Extended related, reverts with non transferable error
+    function _increaseAllowance(address spender, uint256 amount) internal virtual override returns (bool) {
+        revert ERC20Point_nonTransferableToken();
+    }
+
+    /// @dev ERC20Extended related, reverts with non transferable error
+    function _decreaseAllowance(address spender, uint256 amount) internal virtual override returns (bool) {
+        revert ERC20Point_nonTransferableToken();
+    }
+
+    /// @dev ERC20 related, reverts with non transferable error
+    function _approve(address holder, address spender, uint256 amount) internal virtual override returns (bool) {
+        revert ERC20Point_nonTransferableToken();
+    }
+
+    /// @dev ERC20 related, reverts with non transferable error
+    function _burn(address account, uint256 amount) internal virtual override {
+        revert ERC20Point_nonTransferableToken();
+    }
+
+    /// @dev ERC20 related, reverts with non transferable error
+    function _transfer(address holder, address recipient, uint256 amount) internal virtual override returns (bool) {
+        revert ERC20Point_nonTransferableToken();
+    }
+
+    /// @dev ERC20 related, reverts with non transferable error
+    function _transferFrom(address holder, address recipient, uint256 amount) internal virtual override returns (bool) {
+        revert ERC20Point_nonTransferableToken();
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                        Internal (platform fee) functions
+    //////////////////////////////////////////////////////////////*/
+
+    function _checkPlatformFee() internal view returns (address recipient, uint256 amount) {
+        // don't charge platform fee if sender is a contract or globals address is not set
+        if (_isContract(msg.sender) || _getGlobalsAddress() == address(0)) {
+            return (address(0), 0);
+        }
+
+        (recipient, amount) = _platformFeeInfo(0);
+
+        // ensure the ether being sent was included in the transaction
+        if (amount > msg.value) {
+            revert CurrencyTransferLib.CurrencyTransferLib_insufficientValue();
+        }
+    }
+
+    function _payPlatformFee(address recipient, uint256 amount) internal {
+        if (amount == 0) {
+            return;
+        }
+
+        CurrencyTransferLib.safeTransferNativeToken(recipient, amount);
+
+        emit PaidPlatformFee(address(0), amount);
+    }
+
+    /**
+     * @dev derived from Openzepplin's address utils
+     *      https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v4.8.2/contracts/utils/Address.sol
+     */
+
+    function _isContract(address _account) internal view returns (bool) {
+        // This method relies on extcodesize/address.code.length, which returns 0
+        // for contracts in construction, since the code is only stored at the end
+        // of the constructor execution.
+
+        return _account.code.length > 0;
+    }
+}

--- a/src/tokens/ERC20/ERC20PointMock.sol
+++ b/src/tokens/ERC20/ERC20PointMock.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.16;
+
+import {ERC20Point} from "./ERC20Point.sol";
+
+contract ERC20PointMock is ERC20Point {
+    constructor(string memory _name, string memory _symbol, uint8 _decimals, uint256 _supply) payable initializer {
+        initialize(msg.sender, _name, _symbol, _decimals, _supply, "");
+    }
+}

--- a/test/App/App.t.sol
+++ b/test/App/App.t.sol
@@ -5,13 +5,12 @@ pragma solidity ^0.8.16;
 
 import "forge-std/Test.sol";
 import {AppFactory, IApp} from "../../src/factories/App.sol";
-import {ERC20Base} from "src/tokens/ERC20/ERC20Base.sol";
 import {Globals} from "src/globals/Globals.sol";
 
 contract DummyImplementation {
     address public owner;
 
-    function init(address _owner, address _registry, address _globals) external {
+    function init(address _owner, address, address) external {
         owner = _owner;
     }
 
@@ -25,17 +24,12 @@ contract Setup is Test {
 
     AppFactory factory;
     Globals globals;
-
-    ERC20Base erc20Implementation;
     DummyImplementation implementation;
 
     function setUp() public {
         creator = address(0x10);
 
         globals = new Globals();
-
-        erc20Implementation = new ERC20Base();
-
         implementation = new DummyImplementation();
         factory = new AppFactory(address(implementation), address(0), address(0));
     }

--- a/test/integration/App.sol
+++ b/test/integration/App.sol
@@ -14,7 +14,6 @@ import {Proxy} from "../../src/proxy/Proxy.sol";
 import {Upgradable} from "../../src/proxy/upgradable/Upgradable.sol";
 import {RegistryMock} from "../../src/registry/RegistryMock.sol";
 import {AppFactory} from "../../src/factories/App.sol";
-import {ERC20Base} from "src/tokens/ERC20/ERC20Base.sol";
 
 contract MessageFacet {
     string public message = "";
@@ -42,7 +41,6 @@ abstract contract Helpers {
 
 contract Factory__intergration is Test, Helpers {
     AppFactory appFactory;
-    ERC20Base erc20Implementation;
     Proxy template;
     RegistryMock registry;
     MessageFacet message;
@@ -55,7 +53,6 @@ contract Factory__intergration is Test, Helpers {
         registry = new RegistryMock();
         template = new  Proxy(true);
         appFactory = new AppFactory(address(template), address(registry), globals);
-        erc20Implementation = new ERC20Base();
         message = new MessageFacet();
 
         // add hello facet to registry

--- a/test/integration/TransactionLayer.t.sol
+++ b/test/integration/TransactionLayer.t.sol
@@ -24,7 +24,6 @@ import {AppFactory} from "src/factories/App.sol";
 import {Globals} from "src/globals/Globals.sol";
 import {SettingsFacet} from "src/facet/SettingsFacet.sol";
 import {ERC20BaseMock} from "src/tokens/ERC20/ERC20BaseMock.sol";
-import {ERC20Base} from "src/tokens/ERC20/ERC20Base.sol";
 import {CurrencyTransferLib} from "src/lib/CurrencyTransferLib.sol";
 
 import {PlatformFee, IPlatformFee, PlatformFeeInternal} from "src/extensions/platformFee/PlatformFee.sol";
@@ -101,7 +100,6 @@ contract Setup is Test, Helpers {
     RegistryMock registry;
     Globals globals;
     ERC20BaseMock erc20;
-    ERC20Base erc20Implementation;
 
     SettingsFacet settingsFacet;
     DummyDonateFacet facet;
@@ -118,8 +116,6 @@ contract Setup is Test, Helpers {
         template = new  Proxy(true);
         appFactory = new AppFactory(address(template), address(registry), address(globals));
         erc20 = new ERC20BaseMock("Dummy", "D", 18, 1000);
-
-        erc20Implementation = new ERC20Base();
 
         // Add Facets
         {

--- a/test/integration/extensions/PlatformFee.t.sol
+++ b/test/integration/extensions/PlatformFee.t.sol
@@ -18,8 +18,6 @@ import {RegistryMock} from "src/registry/RegistryMock.sol";
 import {AppFactory} from "src/factories/App.sol";
 import {Globals} from "src/globals/Globals.sol";
 
-import {ERC20Base} from "src/tokens/ERC20/ERC20Base.sol";
-
 import {PlatformFee, IPlatformFee} from "src/extensions/platformFee/PlatformFee.sol";
 
 contract DummyFacet is PlatformFee {
@@ -78,7 +76,6 @@ contract Setup is Test, Helpers {
     RegistryMock registry;
     DummyFacet facet;
     Globals globals;
-    ERC20Base erc20Implementation;
 
     function setUp() public {
         creator = address(0x10);
@@ -89,8 +86,6 @@ contract Setup is Test, Helpers {
         template = new  Proxy(true);
         appFactory = new AppFactory(address(template), address(registry), address(globals));
         facet = new DummyFacet();
-
-        erc20Implementation = new ERC20Base();
 
         // add facet to registry
         bytes4[] memory selectors = new bytes4[](2);

--- a/test/integration/facet/ERC20FactoryFacet.t.sol
+++ b/test/integration/facet/ERC20FactoryFacet.t.sol
@@ -18,6 +18,7 @@ import {Globals} from "src/globals/Globals.sol";
 
 import {IERC20Factory} from "@extensions/ERC20Factory/IERC20Factory.sol";
 import {ERC20Base, ADMIN_ROLE, MINTER_ROLE} from "src/tokens/ERC20/ERC20Base.sol";
+import {ERC20Point} from "src/tokens/ERC20/ERC20Point.sol";
 import {ERC20FactoryFacet} from "src/facet/ERC20FactoryFacet.sol";
 
 import {SettingsFacet, IApplicationAccess} from "src/facet/SettingsFacet.sol";
@@ -52,6 +53,9 @@ contract Setup is Test, Helpers {
 
     ERC20Base erc20Implementation;
     bytes32 erc20ImplementationId;
+    ERC20Point erc20PointImplementation;
+    bytes32 erc20PointImplementationId;
+
     ERC20FactoryFacet erc20FactoryFacet;
 
     function setUp() public {
@@ -70,6 +74,9 @@ contract Setup is Test, Helpers {
 
         erc20Implementation = new ERC20Base();
         erc20ImplementationId = bytes32("base");
+        erc20PointImplementation = new ERC20Point();
+        erc20PointImplementationId = bytes32("point");
+
         erc20FactoryFacet = new ERC20FactoryFacet();
 
         // create app
@@ -79,6 +86,7 @@ contract Setup is Test, Helpers {
         // setup globals
         globals.setPlatformFee(0, 0, socialConscious);
         globals.setERC20Implementation(erc20ImplementationId, address(erc20Implementation));
+        globals.setERC20Implementation(erc20PointImplementationId, address(erc20PointImplementation));
 
         settingsFacet = new SettingsFacet();
         {
@@ -124,7 +132,7 @@ contract ERC20FactoryFacet__integration_createERC20 is Setup {
     // to check contracts deployed to same address
     mapping(address => bool) deployments;
 
-    function test_can_create_erc20() public {
+    function test_can_create_erc20base() public {
         vm.prank(creator);
         address erc20Address =
             ERC20FactoryFacet(address(app)).createERC20("name", "symbol", 18, 1000, erc20ImplementationId);
@@ -139,7 +147,22 @@ contract ERC20FactoryFacet__integration_createERC20 is Setup {
         assertTrue(ERC20Base(erc20Address).hasRole(MINTER_ROLE, address(app)));
     }
 
-    function test_can_create_multiple_erc20_contracts() public {
+    function test_can_create_erc20point() public {
+        vm.prank(creator);
+        address erc20Address =
+            ERC20FactoryFacet(address(app)).createERC20("name", "symbol", 18, 1000, erc20PointImplementationId);
+
+        assertEq(ERC20Point(erc20Address).name(), "name");
+        assertEq(ERC20Point(erc20Address).symbol(), "symbol");
+        assertEq(ERC20Point(erc20Address).decimals(), 18);
+        assertEq(ERC20Point(erc20Address).totalSupply(), 1000);
+        assertEq(ERC20Point(erc20Address).balanceOf(creator), 1000);
+
+        assertTrue(ERC20Point(erc20Address).hasRole(ADMIN_ROLE, creator));
+        assertTrue(ERC20Point(erc20Address).hasRole(MINTER_ROLE, address(app)));
+    }
+
+    function test_can_create_multiple_erc20base_contracts() public {
         for (uint256 i = 0; i < 10; i++) {
             vm.prank(creator);
             address deployed =
@@ -152,7 +175,20 @@ contract ERC20FactoryFacet__integration_createERC20 is Setup {
         }
     }
 
-    function test_can_create_erc20_and_pay_platform_fee() public {
+    function test_can_create_multiple_erc20point_contracts() public {
+        for (uint256 i = 0; i < 10; i++) {
+            vm.prank(creator);
+            address deployed =
+                ERC20FactoryFacet(address(app)).createERC20("name", "symbol", 18, 1000, erc20PointImplementationId);
+            if (deployments[deployed] == true) {
+                revert("ERC20Point deployed to the same address");
+            }
+
+            deployments[deployed] = true;
+        }
+    }
+
+    function test_can_create_erc20base_and_pay_platform_fee() public {
         // set platform base fee to 1 ether
         globals.setPlatformFee(1 ether, 0, socialConscious);
 
@@ -160,6 +196,19 @@ contract ERC20FactoryFacet__integration_createERC20 is Setup {
         vm.prank(creator);
         address erc20Address = ERC20FactoryFacet(address(app)).createERC20{value: 1 ether}(
             "name", "symbol", 18, 1000, erc20ImplementationId
+        );
+        // check platform fee has been received
+        assertEq(socialConscious.balance, 1 ether);
+    }
+
+    function test_can_create_erc20point_and_pay_platform_fee() public {
+        // set platform base fee to 1 ether
+        globals.setPlatformFee(1 ether, 0, socialConscious);
+
+        // create nft and pay platform fee
+        vm.prank(creator);
+        address erc20Address = ERC20FactoryFacet(address(app)).createERC20{value: 1 ether}(
+            "name", "symbol", 18, 1000, erc20PointImplementationId
         );
         // check platform fee has been received
         assertEq(socialConscious.balance, 1 ether);
@@ -179,7 +228,7 @@ contract ERC20FactoryFacet__integration_createERC20 is Setup {
         ERC20FactoryFacet(address(app)).createERC20("name", "symbol", 18, 1000, erc20ImplementationId);
     }
 
-    function test_emits_Created_event() public {
+    function test_emits_Created_event_erc20base() public {
         // get deployment address
         vm.prank(creator);
         address expectedAddress =
@@ -193,10 +242,30 @@ contract ERC20FactoryFacet__integration_createERC20 is Setup {
         ERC20FactoryFacet(address(app)).createERC20("name", "symbol", 18, 1000, erc20ImplementationId);
     }
 
-    function test_reverts_when_do_not_have_permission() public {
+    function test_emits_Created_event_erc20point() public {
+        // get deployment address
+        vm.prank(creator);
+        address expectedAddress =
+            ERC20FactoryFacet(address(app)).calculateERC20FactoryDeploymentAddress(erc20PointImplementationId);
+
+        vm.expectEmit(false, true, true, true);
+        emit Created(expectedAddress, creator, "name", "symbol", 18, 1000, erc20PointImplementationId);
+
+        // create nft and pay platform fee
+        vm.prank(creator);
+        ERC20FactoryFacet(address(app)).createERC20("name", "symbol", 18, 1000, erc20PointImplementationId);
+    }
+
+    function test_reverts_when_do_not_have_permission_erc20base() public {
         vm.expectRevert(IERC20Factory.ERC20Factory_doNotHavePermission.selector);
         vm.prank(other);
         ERC20FactoryFacet(address(app)).createERC20("name", "symbol", 18, 1000, erc20ImplementationId);
+    }
+
+    function test_reverts_when_do_not_have_permission_erc20point() public {
+        vm.expectRevert(IERC20Factory.ERC20Factory_doNotHavePermission.selector);
+        vm.prank(other);
+        ERC20FactoryFacet(address(app)).createERC20("name", "symbol", 18, 1000, erc20PointImplementationId);
     }
 
     function test_reverts_when_no_implementation_is_found() public {
@@ -232,9 +301,14 @@ contract ERC20FactoryFacet__integration_createERC20 is Setup {
 }
 
 contract ERC20FactoryFacet__integration_getERC20FactoryImplementation is Setup {
-    function test_returns_implementation_address() public {
+    function test_returns_erc20base_implementation_address() public {
         address implementation = ERC20FactoryFacet(address(app)).getERC20FactoryImplementation(erc20ImplementationId);
         assertEq(implementation, address(erc20Implementation));
+    }
+
+    function test_returns_erc20point_implementation_address() public {
+        address implementation = ERC20FactoryFacet(address(app)).getERC20FactoryImplementation(erc20PointImplementationId);
+        assertEq(implementation, address(erc20PointImplementation));
     }
 
     function test_returns_zero_address_if_no_implementation_found() public {
@@ -244,7 +318,7 @@ contract ERC20FactoryFacet__integration_getERC20FactoryImplementation is Setup {
 }
 
 contract ERC20FactoryFacet__integration_calculateERC20DeploymentAddress is Setup {
-    function test_returns_correct_deployment_address() public {
+    function test_returns_correct_erc20base_deployment_address() public {
         vm.prank(creator);
         address deploymentAddress =
             ERC20FactoryFacet(address(app)).calculateERC20FactoryDeploymentAddress(erc20ImplementationId);
@@ -252,6 +326,17 @@ contract ERC20FactoryFacet__integration_calculateERC20DeploymentAddress is Setup
         vm.prank(creator);
         address actualDeploymentAddress =
             ERC20FactoryFacet(address(app)).createERC20("name", "symbol", 18, 1000, erc20ImplementationId);
+        assertEq(deploymentAddress, actualDeploymentAddress);
+    }
+
+    function test_returns_correct_erc20point_deployment_address() public {
+        vm.prank(creator);
+        address deploymentAddress =
+            ERC20FactoryFacet(address(app)).calculateERC20FactoryDeploymentAddress(erc20PointImplementationId);
+
+        vm.prank(creator);
+        address actualDeploymentAddress =
+            ERC20FactoryFacet(address(app)).createERC20("name", "symbol", 18, 1000, erc20PointImplementationId);
         assertEq(deploymentAddress, actualDeploymentAddress);
     }
 

--- a/test/integration/facet/ERC721FactoryFacet.t.sol
+++ b/test/integration/facet/ERC721FactoryFacet.t.sol
@@ -16,7 +16,6 @@ import {RegistryMock} from "src/registry/RegistryMock.sol";
 import {AppFactory} from "src/factories/App.sol";
 import {Globals} from "src/globals/Globals.sol";
 
-import {ERC20Base} from "src/tokens/ERC20/ERC20Base.sol";
 import {IERC721Factory} from "@extensions/ERC721Factory/IERC721Factory.sol";
 import {ERC721Base, ADMIN_ROLE, MINTER_ROLE} from "src/tokens/ERC721/ERC721Base.sol";
 import {ERC721LazyMint} from "src/tokens/ERC721/ERC721LazyMint.sol";
@@ -58,7 +57,6 @@ contract Setup is Test, Helpers {
 
     SettingsFacet settingsFacet;
 
-    ERC20Base erc20Implementation;
     ERC721Base erc721Implementation;
     bytes32 erc721ImplementationId;
     ERC721FactoryFacet erc721FactoryFacet;
@@ -76,8 +74,6 @@ contract Setup is Test, Helpers {
         registry = new RegistryMock();
         appImplementation = new Proxy(true);
         appFactory = new AppFactory(address(appImplementation), address(registry), address(globals));
-
-        erc20Implementation = new ERC20Base();
 
         erc721Implementation = new ERC721Base();
         erc721ImplementationId = bytes32("Base");

--- a/test/integration/facet/ERC721LazyDrop.t.sol
+++ b/test/integration/facet/ERC721LazyDrop.t.sol
@@ -17,7 +17,6 @@ import {AppFactory} from "src/factories/App.sol";
 import {Globals} from "src/globals/Globals.sol";
 
 import {ERC20BaseMock} from "src/tokens/ERC20/ERC20BaseMock.sol";
-import {ERC20Base} from "src/tokens/ERC20/ERC20Base.sol";
 import {ERC721LazyMint} from "src/tokens/ERC721/ERC721LazyMint.sol";
 
 import {ERC721LazyDropFacet, ERC721LazyDropStorage} from "src/facet/ERC721LazyDropFacet.sol";
@@ -69,7 +68,6 @@ contract Setup is Test, Helpers {
 
     ERC721LazyMint erc721;
     ERC20BaseMock erc20;
-    ERC20Base erc20Implementation;
 
     function setUp() public {
         // assign addresses
@@ -85,8 +83,6 @@ contract Setup is Test, Helpers {
         registry = new RegistryMock();
         appImplementation = new  Proxy(true);
         appFactory = new AppFactory(address(appImplementation), address(registry), address(globals));
-
-        erc20Implementation = new ERC20Base();
 
         {
             settingsFacet = new SettingsFacet();

--- a/test/integration/facet/SettingsFacet.t.sol
+++ b/test/integration/facet/SettingsFacet.t.sol
@@ -16,7 +16,6 @@ import {Upgradable} from "src/proxy/upgradable/Upgradable.sol";
 import {RegistryMock} from "src/registry/RegistryMock.sol";
 import {AppFactory} from "src/factories/App.sol";
 import {Globals} from "src/globals/Globals.sol";
-import {ERC20Base} from "src/tokens/ERC20/ERC20Base.sol";
 
 import {SettingsFacet, IApplicationAccess} from "src/facet/SettingsFacet.sol";
 

--- a/test/integration/tokens/ERC20Point.t.sol
+++ b/test/integration/tokens/ERC20Point.t.sol
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.16;
+
+// The following tests ERC20Point integration with Globals ERC20FactoryFacet and platform fees
+
+import "forge-std/Test.sol";
+
+import {
+    IDiamondWritable,
+    IDiamondWritableInternal
+} from "@solidstate/contracts/proxy/diamond/writable/IDiamondWritable.sol";
+
+import {Proxy} from "src/proxy/Proxy.sol";
+import {Upgradable} from "src/proxy/upgradable/Upgradable.sol";
+import {RegistryMock} from "src/registry/RegistryMock.sol";
+import {AppFactory} from "src/factories/App.sol";
+import {Globals} from "src/globals/Globals.sol";
+
+import {ERC20Point, ADMIN_ROLE, MINTER_ROLE} from "src/tokens/ERC20/ERC20Point.sol";
+import {IERC20Factory} from "@extensions/ERC20Factory/IERC20Factory.sol";
+import {ERC20FactoryFacet} from "src/facet/ERC20FactoryFacet.sol";
+import {SettingsFacet, IApplicationAccess} from "src/facet/SettingsFacet.sol";
+
+import {Deploy} from "scripts/core/Globals.s.sol";
+
+abstract contract Helpers {
+    function prepareSingleFacetCut(
+        address cutAddress,
+        IDiamondWritableInternal.FacetCutAction cutAction,
+        bytes4[] memory selectors
+    ) public pure returns (IDiamondWritableInternal.FacetCut[] memory) {
+        IDiamondWritableInternal.FacetCut[] memory cuts = new IDiamondWritableInternal.FacetCut[](1);
+        cuts[0] = IDiamondWritableInternal.FacetCut(cutAddress, cutAction, selectors);
+        return cuts;
+    }
+}
+
+/**
+ * @dev dummy contract to test platform fee is not paid when called from a contract
+ *      must first grant MINTER_ROLE to this contract
+ */
+
+contract MinterDummy {
+    function mintTo(address _erc20, address _account, uint256 _amount) public {
+        ERC20Point(_erc20).mintTo(_account, _amount);
+    }
+}
+
+contract Setup is Test, Helpers {
+    address creator;
+    address other;
+    address socialConscious;
+
+    AppFactory appFactory;
+    Proxy appImplementation;
+    Proxy app;
+    RegistryMock registry;
+    Globals globals;
+
+    SettingsFacet settingsFacet;
+
+    ERC20Point erc20Implementation;
+    bytes32 erc20ImplementationId;
+    ERC20FactoryFacet erc20FactoryFacet;
+
+    function setUp() public {
+        // assign addresses
+        creator = address(0x10);
+        other = address(0x11);
+        socialConscious = address(0x12);
+
+        vm.deal(creator, 1 ether);
+
+        // deploy contracts
+        globals = new Globals();
+        registry = new RegistryMock();
+        appImplementation = new  Proxy(true);
+        appFactory = new AppFactory(address(appImplementation), address(registry), address(globals));
+
+        erc20Implementation = new ERC20Point();
+        erc20ImplementationId = bytes32("Point");
+        erc20FactoryFacet = new ERC20FactoryFacet();
+
+        // create app
+        vm.prank(creator);
+        app = Proxy(payable(appFactory.create("platformFeeTest", creator)));
+
+        // setup globals
+        globals.setPlatformFee(0, 0, socialConscious);
+        globals.setERC20Implementation(erc20ImplementationId, address(erc20Implementation));
+
+        settingsFacet = new SettingsFacet();
+        {
+            // add SettingsFacet to registry
+            bytes4[] memory selectors = new bytes4[](1);
+            selectors[0] = settingsFacet.setCreatorAccess.selector;
+
+            registry.diamondCut(
+                prepareSingleFacetCut(address(settingsFacet), IDiamondWritableInternal.FacetCutAction.ADD, selectors),
+                address(0),
+                ""
+            );
+        }
+
+        {
+            // add erc20FactoryFacet to registry
+            bytes4[] memory selectors = new bytes4[](3);
+            selectors[0] = erc20FactoryFacet.createERC20.selector;
+            selectors[1] = erc20FactoryFacet.getERC20FactoryImplementation.selector;
+            selectors[2] = erc20FactoryFacet.calculateERC20FactoryDeploymentAddress.selector;
+            registry.diamondCut(
+                prepareSingleFacetCut(
+                    address(erc20FactoryFacet), IDiamondWritableInternal.FacetCutAction.ADD, selectors
+                ),
+                address(0),
+                ""
+            );
+        }
+
+        _afterSetup();
+    }
+
+    /**
+     * @dev override to add more setup per test contract
+     */
+    function _afterSetup() internal virtual {}
+}
+
+contract ERC20Point_Setup is Setup {
+    ERC20Point point;
+    MinterDummy minter;
+
+    function _afterSetup() internal override {
+        ERC20Point pointImplementation = new ERC20Point();
+        bytes32 pointImplementationId = bytes32("Point");
+        globals.setERC20Implementation(pointImplementationId, address(pointImplementation));
+
+        // create lazy mint erc20
+        vm.prank(creator);
+        // forgefmt: disable-start
+        point = ERC20Point(
+            ERC20FactoryFacet(address(app)).createERC20(
+                "name",
+                "symbol",
+                18,
+                0,
+                pointImplementationId
+            )
+        );
+        // forgefmt: disable-end
+
+        // create contract that can mint
+        minter = new MinterDummy();
+        // grant minter role to minter contract
+        vm.prank(creator);
+        point.grantRole(MINTER_ROLE, address(minter));
+    }
+}
+
+contract ERC20Point__integration_mintTo is ERC20Point_Setup {
+    function test_mints_nft() public {
+        vm.prank(creator);
+        point.mintTo(creator, 1000);
+
+        // check nft is minted to creator
+        assertEq(point.balanceOf(creator), 1000);
+    }
+
+    function test_pays_platform_fee() public {
+        // set platform base fee to 0.001 ether
+        uint256 basePlatformFee = 0.001 ether;
+        globals.setPlatformFee(basePlatformFee, 0, socialConscious);
+
+        vm.prank(creator);
+        point.mintTo{value: basePlatformFee}(creator, 1000);
+
+        // check platform fee has been received
+        assertEq(socialConscious.balance, basePlatformFee);
+    }
+
+    function test_does_not_pay_platform_fee_when_called_from_contract() public {
+        // set platform base fee to 0.001 ether
+        uint256 basePlatformFee = 0.001 ether;
+        globals.setPlatformFee(basePlatformFee, 0, socialConscious);
+
+        minter.mintTo(address(point), creator, 1000);
+        assertEq(point.balanceOf(creator), 1000);
+    }
+}

--- a/test/integration/tokens/ERC721Base.t.sol
+++ b/test/integration/tokens/ERC721Base.t.sol
@@ -16,7 +16,6 @@ import {RegistryMock} from "src/registry/RegistryMock.sol";
 import {AppFactory} from "src/factories/App.sol";
 import {Globals} from "src/globals/Globals.sol";
 
-import {ERC20Base} from "src/tokens/ERC20/ERC20Base.sol";
 import {ERC721Base, ADMIN_ROLE, MINTER_ROLE} from "src/tokens/ERC721/ERC721Base.sol";
 import {IERC721Factory} from "@extensions/ERC721Factory/IERC721Factory.sol";
 import {ERC721FactoryFacet} from "src/facet/ERC721FactoryFacet.sol";
@@ -63,7 +62,6 @@ contract Setup is Test, Helpers {
 
     SettingsFacet settingsFacet;
 
-    ERC20Base erc20Implementation;
     ERC721Base erc721Implementation;
     bytes32 erc721ImplementationId;
     ERC721FactoryFacet erc721FactoryFacet;

--- a/test/integration/tokens/ERC721LazyMint.t.sol
+++ b/test/integration/tokens/ERC721LazyMint.t.sol
@@ -16,7 +16,6 @@ import {RegistryMock} from "src/registry/RegistryMock.sol";
 import {AppFactory} from "src/factories/App.sol";
 import {Globals} from "src/globals/Globals.sol";
 
-import {ERC20Base} from "src/tokens/ERC20/ERC20Base.sol";
 import {ERC721Base, ADMIN_ROLE, MINTER_ROLE} from "src/tokens/ERC721/ERC721Base.sol";
 import {ERC721LazyMint} from "src/tokens/ERC721/ERC721LazyMint.sol";
 import {IERC721Factory} from "@extensions/ERC721Factory/IERC721Factory.sol";
@@ -67,8 +66,6 @@ contract Setup is Test, Helpers {
     Globals globals;
 
     SettingsFacet settingsFacet;
-
-    ERC20Base erc20Implementation;
     ERC721Base erc721Implementation;
     bytes32 erc721ImplementationId;
     ERC721FactoryFacet erc721FactoryFacet;
@@ -86,8 +83,6 @@ contract Setup is Test, Helpers {
         registry = new RegistryMock();
         appImplementation = new Proxy(true);
         appFactory = new AppFactory(address(appImplementation), address(registry), address(globals));
-
-        erc20Implementation = new ERC20Base();
 
         erc721Implementation = new ERC721Base();
         erc721ImplementationId = bytes32("Base");

--- a/test/tokens/ERC20/ERC20Point.t.sol
+++ b/test/tokens/ERC20/ERC20Point.t.sol
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.16;
+
+import "forge-std/Test.sol";
+import {ERC20PointMock, ERC20Point} from "../../../src/tokens/ERC20/ERC20PointMock.sol";
+
+import {IERC165} from "@solidstate/contracts/interfaces/IERC165.sol";
+import {IERC20} from "@solidstate/contracts/interfaces/IERC20.sol";
+import {IERC2612} from "@solidstate/contracts/token/ERC20/permit/IERC2612.sol";
+
+import {IContractMetadata} from "@extensions/contractMetadata/ContractMetadata.sol";
+import {IInitializable} from "@extensions/initializable/IInitializable.sol";
+
+bytes32 constant ADMIN_ROLE = bytes32(uint256(0));
+bytes32 constant MINTER_ROLE = bytes32(uint256(1));
+
+contract Setup is Test {
+    address creator = address(0x10);
+    address other = address(0x11);
+    ERC20PointMock erc20Point;
+
+    // ipfs uri taken from https://docs.ipfs.tech/how-to/best-practices-for-nft-data/#types-of-ipfs-links-and-when-to-use-them
+    string contractURI = "ipfs://bafybeibnsoufr2renqzsh347nrx54wcubt5lgkeivez63xvivplfwhtpym/";
+
+    function setUp() public {
+        vm.prank(creator);
+        erc20Point = new ERC20PointMock(
+          "Name",
+          "Symbol",
+          18,
+          10_000
+        );
+
+        afterSetUp();
+    }
+
+    // can override this function to perform further setup tasks
+    function afterSetUp() public virtual {}
+}
+
+contract ERC20__initialize is Setup {
+    function test_sets_admin() public {
+        assertTrue(erc20Point.hasRole(ADMIN_ROLE, creator));
+    }
+
+    function test_sets_name() public {
+        assertEq(erc20Point.name(), "Name");
+    }
+
+    function test_sets_symbol() public {
+        assertEq(erc20Point.symbol(), "Symbol");
+    }
+
+    function test_sets_decimal() public {
+        assertEq(erc20Point.decimals(), 18);
+    }
+
+    function test_mints_supply_to_owner() public {
+        assertEq(erc20Point.balanceOf(creator), 10_000);
+    }
+
+    function test_supports_IERC165_interfaces() public {
+        assertTrue(erc20Point.supportsInterface(type(IERC165).interfaceId));
+    }
+
+    function test_supports_ERC20_interfaces() public {
+        assertTrue(erc20Point.supportsInterface(type(IERC20).interfaceId));
+    }
+
+    function test_supports_IERC2612_interfaces() public {
+        assertTrue(erc20Point.supportsInterface(type(IERC2612).interfaceId));
+    }
+
+    function test_supports_IContractMetadata_interfaces() public {
+        assertTrue(erc20Point.supportsInterface(type(IContractMetadata).interfaceId));
+    }
+
+    function test_cannot_be_initialized_again() public {
+        vm.expectRevert(IInitializable.Initializable_contractIsAlreadyInitialized.selector);
+        erc20Point.initialize(other, "Name", "Symbol", 18, 10_000, "");
+    }
+}
+
+contract ERC20__mintTo is Setup {
+    function test_can_mint_to_an_address() public {
+        vm.prank(creator);
+        erc20Point.mintTo(other, 10_000);
+        assertEq(erc20Point.balanceOf(other), 10_000);
+    }
+
+    function test_reverts_if_not_the_owner() public {
+        vm.prank(other);
+        vm.expectRevert(ERC20Point.ERC20Point_notAuthorized.selector);
+        erc20Point.mintTo(other, 10_000);
+    }
+
+    function test_reverts_amount_is_zero() public {
+        vm.prank(creator);
+        vm.expectRevert(ERC20Point.ERC20Point_zeroAmount.selector);
+        erc20Point.mintTo(other, 0);
+    }
+}
+
+contract ERC20__burn is Setup {
+    function test_can_burn() public {
+        vm.prank(creator);
+        vm.expectRevert(ERC20Point.ERC20Point_nonTransferableToken.selector);
+        erc20Point.burn(10_000);
+    }
+}
+
+contract ERC20__setContractURI is Setup {
+    function test_sets_contract_uri() public {
+        vm.prank(creator);
+        erc20Point.setContractURI(contractURI);
+
+        assertEq(contractURI, erc20Point.contractURI());
+    }
+
+    function test_reverts_if_not_the_owner() public {
+        vm.prank(other);
+        vm.expectRevert();
+        erc20Point.setContractURI(contractURI);
+    }
+}
+
+contract ERC20B__multicall is Setup {
+    function test_can_perfom_multiple_calls_in_one_transaction() public {
+        bytes[] memory calls = new bytes[](2);
+        calls[0] = abi.encodeCall(erc20Point.mintTo, (other, 1_000));
+        calls[1] = abi.encodeCall(erc20Point.mintTo, (other, 1_000));
+
+        vm.prank(creator);
+        erc20Point.multicall(calls);
+
+        assertEq(erc20Point.balanceOf(other), 2_000);
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds a new ERC20 contract for non transferable tokens.

## Description

New contract `ERC20Point` adds support for ERC20 non transferable tokens. This contract is based on existing `ERC20Base` with all transfer related functions reverting with new error type `ERC20Point_nonTransferableToken`.

Command `make deploy-ERC20Point` adds new ERC20 implementation with id "Point" to Globals, calling `RewardsFacet.createERC20` with new id will create a new `ERC20Point`.

## Type of Change

Please check the boxes that apply to your pull request:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (changes to documentation only)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Testing

Tests for new contract have been added.

Some tests have been cleaned of unnecessary references to `ERC20Base`.

