### PR TITLE
Deploy ERC20Point contract to arbitrum sepolia and staging

### DIFF
--- a/deployed/421614-staging.json
+++ b/deployed/421614-staging.json
@@ -15,6 +15,10 @@
     "address": "0x2C227862Be6F0B1A6fd398E0630A60C09B34A077",
     "startBlock": 53195102
   },
+  "ERC20Point": {
+    "address": "0x81c44F762785dD26FC94E4c549B872E9FE19c2dD",
+    "startBlock": 106106959
+  },
   "ERC721Badge": {
     "address": "0x9f5c73BffCD63c5e9d1ADf18aAc9D6F6695EAe70",
     "startBlock": 53194358
@@ -84,6 +88,7 @@
     "Open_Format_App",
     "XP",
     "OFT",
-    "ChargeFacet"
+    "ChargeFacet",
+    "ERC20Point"
   ]
 }

--- a/deployed/421614.json
+++ b/deployed/421614.json
@@ -15,6 +15,10 @@
     "address": "0xAdbbCC5B721F83b0fE349AB82D4fCC68AaCDFAC3",
     "startBlock": 32647834
   },
+  "ERC20Point": {
+    "address": "0x7CCf50eD9E278E80E6C050c08aEC37E4c0d58f10",
+    "startBlock": 106106574
+  },
   "ERC721Badge": {
     "address": "0x5228a91b560718868dE04C79045ed7383fe2a97C",
     "startBlock": 61035266
@@ -89,6 +93,7 @@
     "ERC721Badge",
     "Open_Format_App",
     "XP",
-    "OFT"
+    "OFT",
+    "ERC20Point"
   ]
 }


### PR DESCRIPTION
Deploys the ERCPoint contract so it can be used with `arbitrum-sepolia` and `arbitrum-sepolian-staging` contracts