### PR TITLE
Feature/of 733 add non transferable badge contract

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ deploy:; make \
 	deploy-ERC721Base \
 	deploy-ERC721LazyMint \
 	deploy-ERC721Badge \
+	deploy-ERC721BadgeNonTransferable \
 	deploy-RewardsFacet \
 	deploy-SettingsFacet \
 	deploy-ERC721FactoryFacet \
@@ -48,6 +49,7 @@ deploy-AppFactory:; forge script scripts/core/AppFactory.s.sol:Deploy --rpc-url 
 deploy-ERC721Base:; forge script scripts/tokens/ERC721Base.s.sol:Deploy --rpc-url $(rpc) --broadcast $(verbose) $(gasPrice) $(legacy) $(slow)
 deploy-ERC721LazyMint:; forge script scripts/tokens/ERC721LazyMint.s.sol:Deploy --rpc-url $(rpc) --broadcast $(verbose) $(gasPrice) $(legacy) $(slow)
 deploy-ERC721Badge:; forge script scripts/tokens/ERC721Badge.s.sol:Deploy --rpc-url $(rpc) --broadcast $(verbose) $(gasPrice) $(legacy) $(slow)
+deploy-ERC721BadgeNonTransferable:; forge script scripts/tokens/ERC721BadgeNonTransferable.s.sol:Deploy --rpc-url $(rpc) --broadcast $(verbose) $(gasPrice) $(legacy) $(slow)
 deploy-ERC20Base:; forge script scripts/tokens/ERC20Base.s.sol:Deploy --rpc-url $(rpc) --broadcast $(verbose) $(gasPrice) $(legacy) $(slow)
 deploy-ERC20Point:; forge script scripts/tokens/ERC20Point.s.sol:Deploy --rpc-url $(rpc) --broadcast $(verbose) $(gasPrice) $(legacy) $(slow)
 
@@ -114,9 +116,19 @@ createERC721Base:; forge script scripts/facet/ERC721FactoryFacet.s.sol:CreateBas
 # Note: make sure app is setup with correct permissions and APP_ID env is set.
 createERC721Badge:; forge script scripts/facet/ERC721FactoryFacet.s.sol:CreateBadge --rpc-url $(rpc) --broadcast $(verbose) $(legacy) $(slow)
 
+# example `make createERC721BadgeNonTransferable`
+# Note: make sure app is setup with correct permissions and APP_ID env is set.
+createERC721BadgeNonTransferable:; forge script scripts/facet/ERC721FactoryFacet.s.sol:CreateBadgeNonTransferable --rpc-url $(rpc) --broadcast $(verbose) $(legacy) $(slow)
+
 # example: make ERC721Badge.mintTo args="0xaf4c80136581212185f37c5e8809120d8fbf6224"
 ERC721Badge.mintTo:; forge script \
 	scripts/tokens/ERC721Badge.s.sol:MintTo \
+	--sig "run(address)" \
+ 	--rpc-url $(rpc) --broadcast $(verbose) $(legacy) $(slow) $(args)
+
+# example: make ERC721BadgeNonTransferable.mintTo args="0xaf4c80136581212185f37c5e8809120d8fbf6224"
+ERC721BadgeNonTransferable.mintTo:; forge script \
+	scripts/tokens/ERC721BadgeNonTransferable.s.sol:MintTo \
 	--sig "run(address)" \
  	--rpc-url $(rpc) --broadcast $(verbose) $(legacy) $(slow) $(args)
 

--- a/scripts/facet/ERC721FactoryFacet.s.sol
+++ b/scripts/facet/ERC721FactoryFacet.s.sol
@@ -71,6 +71,20 @@ contract CreateBadge is Script, Utils {
     }
 }
 
+contract CreateBadgeNonTransferable is Script, Utils {
+    function run() external {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        address appId = vm.envAddress("APP_ID");
+        vm.startBroadcast(deployerPrivateKey);
+
+        ERC721FactoryFacet erc721FactoryFacet = ERC721FactoryFacet(appId);
+
+        erc721FactoryFacet.createERC721WithTokenURI("TEST", "TEST", "TokenURI", address(0x1), 1000, "BadgeNonTransferable");
+
+        vm.stopBroadcast();
+    }
+}
+
 contract Update is Script, Utils {
     function run() external {
         uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");

--- a/scripts/tokens/ERC721BadgeNonTransferable.s.sol
+++ b/scripts/tokens/ERC721BadgeNonTransferable.s.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.16;
+
+import "forge-std/Script.sol";
+import {Utils} from "scripts/utils/Utils.sol";
+import {ERC721BadgeNonTransferable} from "src/tokens/ERC721/ERC721BadgeNonTransferable.sol";
+import {Globals} from "src/globals/Globals.sol";
+
+string constant CONTRACT_NAME = "ERC721BadgeNonTransferable";
+bytes32 constant implementationId = "BadgeNonTransferable";
+
+contract Deploy is Script, Utils {
+    function run() external {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        vm.startBroadcast(deployerPrivateKey);
+
+        // deploy
+        ERC721BadgeNonTransferable erc721BadgeNonTransferable = new ERC721BadgeNonTransferable(false);
+
+        // add to globals
+        Globals(getContractDeploymentAddress("Globals")).setERC721Implementation(implementationId, address(erc721BadgeNonTransferable));
+
+        vm.stopBroadcast();
+
+        exportContractDeployment(CONTRACT_NAME, address(erc721BadgeNonTransferable), block.number);
+    }
+}
+
+contract SetBaseURI is Script, Utils {
+    function run(address _contractAddress, string memory _baseURIForTokens) external {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        address deployerAddress = vm.addr(deployerPrivateKey);
+        vm.startBroadcast(deployerPrivateKey);
+
+        ERC721BadgeNonTransferable erc721BadgeNonTransferable = ERC721BadgeNonTransferable(_contractAddress);
+        erc721BadgeNonTransferable.setBaseURI(_baseURIForTokens);
+
+        vm.stopBroadcast();
+    }
+}
+
+contract MintTo is Script, Utils {
+    function run(address _contractAddress) external {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        address deployerAddress = vm.addr(deployerPrivateKey);
+        vm.startBroadcast(deployerPrivateKey);
+
+        ERC721BadgeNonTransferable erc721BadgeNonTransferable = ERC721BadgeNonTransferable(_contractAddress);
+        erc721BadgeNonTransferable.mintTo(deployerAddress);
+
+        vm.stopBroadcast();
+    }
+}

--- a/src/tokens/ERC721/ERC721BadgeNonTransferable.sol
+++ b/src/tokens/ERC721/ERC721BadgeNonTransferable.sol
@@ -1,0 +1,344 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.16;
+
+import "forge-std/Script.sol";
+
+import {IERC165} from "@solidstate/contracts/interfaces/IERC165.sol";
+import {IERC721} from "@solidstate/contracts/interfaces/IERC721.sol";
+import {IERC2981} from "@solidstate/contracts/interfaces/IERC2981.sol";
+import {AccessControl} from "@solidstate/contracts/access/access_control/AccessControl.sol";
+import {Multicall} from "@solidstate/contracts/utils/Multicall.sol";
+import {ERC165BaseInternal} from "@solidstate/contracts/introspection/ERC165/base/ERC165BaseInternal.sol";
+import {UintUtils} from "@solidstate/contracts/utils/UintUtils.sol";
+import {ReentrancyGuard} from "@solidstate/contracts/utils/ReentrancyGuard.sol";
+import {Ownable} from "@solidstate/contracts/access/ownable/Ownable.sol";
+
+import {ERC721AUpgradeable} from "@erc721a-upgradeable/contracts/ERC721AUpgradeable.sol";
+
+import {Royalty} from "@extensions/royalty/Royalty.sol";
+import {BatchMintMetadata} from "@extensions/batchMintMetadata/BatchMintMetadata.sol";
+import {ContractMetadata, IContractMetadata} from "@extensions/contractMetadata/ContractMetadata.sol";
+import {Global} from "@extensions/global/Global.sol";
+import {PlatformFee} from "@extensions/platformFee/PlatformFee.sol";
+
+import {CurrencyTransferLib} from "src/lib/CurrencyTransferLib.sol";
+
+string constant CONTRACT_VERSION = "0.1.0";
+string constant CONTRACT_NAME = "ERC721BadgeNonTransferable";
+
+bytes32 constant ADMIN_ROLE = bytes32(uint256(0));
+bytes32 constant MINTER_ROLE = bytes32(uint256(1));
+
+uint256 constant MAX_INT = 2 ** 256 - 1;
+
+contract ERC721BadgeNonTransferable is
+    ERC721AUpgradeable,
+    AccessControl,
+    ERC165BaseInternal,
+    ContractMetadata,
+    BatchMintMetadata,
+    Royalty,
+    Multicall,
+    Global,
+    PlatformFee,
+    ReentrancyGuard,
+    Ownable
+{
+    error ERC721BadgeNonTransferable_notAuthorized();
+    error ERC721BadgeNonTransferable_insufficientLazyMintedTokens();
+    error ERC721BadgeNonTransferable_nonTransferable();
+
+    event Minted(address to, string tokenURI);
+    event BatchMinted(address to, uint256 quantity, string baseURI);
+    event UpdatedBaseURI(string baseURIForTokens);
+    event BatchMetadataUpdate(uint256 fromTokenId, uint256 toTokenId);
+
+    /**
+     * @dev this contract is meant to be an implementation for a factory contract
+     *      calling initialize in constructor prevents the implementation from being used by third party
+     * @param _isTest used to prevent the initialisation. Set to true in unit tests and false in production
+     */
+    constructor(bool _isTest) {
+        if (!_isTest) {
+            initialize(address(0), "", "", address(0), 0, "");
+        }
+    }
+
+    /**
+     * @dev initialize should be called from a trusted contract and not directly by an account.
+     *      platform fee could easily be bypassed by not properly encoding data.
+     *
+     * @param _data bytes encoded with the signature (address,address,string)
+     *              the first will be granted a minter role
+     *              the second address will be set as the globals address
+     *              used to calculate platform fees
+     *              The string is the baseURI for all tokens on the contract
+     */
+    function initialize(
+        address _owner,
+        string memory _name,
+        string memory _symbol,
+        address _royaltyRecipient,
+        uint16 _royaltyBps,
+        bytes memory _data
+    ) public virtual initializerERC721A {
+        __ERC721A_init(_name, _symbol);
+        _grantRole(ADMIN_ROLE, _owner);
+        _setOwner(_owner);
+        _setDefaultRoyaltyInfo(_royaltyRecipient, _royaltyBps);
+
+        _setSupportsInterface(type(IERC165).interfaceId, true);
+        _setSupportsInterface(type(IERC721).interfaceId, true);
+        _setSupportsInterface(type(IERC2981).interfaceId, true);
+        _setSupportsInterface(type(IContractMetadata).interfaceId, true);
+
+        if (_data.length == 0) {
+            return;
+        }
+
+        // decode data to app address and globals address
+        (address app, address globals, string memory baseURIForTokens) = abi.decode(_data, (address, address, string));
+
+        if (app != address(0)) {
+            _grantRole(MINTER_ROLE, app);
+        }
+
+        if (globals != address(0)) {
+            _setGlobals(globals);
+        }
+
+        if (bytes(baseURIForTokens).length > 0) {
+            _batchMintMetadata(0, MAX_INT, baseURIForTokens);
+            emit BatchMetadataUpdate(0, MAX_INT);
+            emit UpdatedBaseURI(baseURIForTokens);
+        }
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                            ERC165 Logic
+    //////////////////////////////////////////////////////////////*/
+
+    /**
+     * @dev override ERC721AUpgradeable to use solidstates ERC165BaseInternal
+     */
+    function supportsInterface(bytes4 interfaceId) public view override(ERC721AUpgradeable, IERC165) returns (bool) {
+        return _supportsInterface(interfaceId);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                        Overriden ERC721A logic
+    //////////////////////////////////////////////////////////////*/
+
+    /**
+     *  @notice         Returns the metadata URI for an NFT.
+     *  @dev            See `BatchMintMetadata` for handling of metadata in this contract.
+     *
+     *  @param _tokenId The tokenId of an NFT.
+     */
+    function tokenURI(uint256 _tokenId) public view virtual override returns (string memory) {
+        // tokenURI was stored using batchMintTo
+        return _getBaseURI(_tokenId);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                            Minting logic
+    //////////////////////////////////////////////////////////////*/
+
+    /**
+     * @notice Lets an authorized address set base uri for all tokens
+     * @param _baseURIForTokens the base URI to be set for all tokens
+     *
+     */
+    function setBaseURI(string calldata _baseURIForTokens) public payable nonReentrant {
+        if (!_canSetBaseURI()) {
+            revert ERC721BadgeNonTransferable.ERC721BadgeNonTransferable_notAuthorized();
+        }
+
+        (address platformFeeRecipient, uint256 platformFeeAmount) = _checkPlatformFee();
+
+        // there will only ever be a baseURICount of zero or one
+        if (_getBaseURICount() > 0) {
+            _setBaseURI(MAX_INT, _baseURIForTokens);
+        } else {
+            _batchMintMetadata(0, MAX_INT, _baseURIForTokens);
+        }
+
+        emit BatchMetadataUpdate(0, MAX_INT);
+        emit UpdatedBaseURI(_baseURIForTokens);
+
+        _payPlatformFee(platformFeeRecipient, platformFeeAmount);
+    }
+
+    /**
+     *  @notice          Lets an authorized address mint an NFT to a recipient.
+     *  @dev             The logic in the `_canMint` function determines whether the caller is authorized to mint NFTs.
+     *
+     *  @param _to       The recipient of the NFT to mint.
+     */
+    function mintTo(address _to) public payable virtual nonReentrant {
+        if (!_canMint()) {
+            revert ERC721BadgeNonTransferable_notAuthorized();
+        }
+
+        (address platformFeeRecipient, uint256 platformFeeAmount) = _checkPlatformFee();
+
+        uint256 tokenId = _nextTokenId();
+
+        _safeMint(_to, 1);
+
+        emit Minted(_to, _getBaseURI(tokenId));
+
+        _payPlatformFee(platformFeeRecipient, platformFeeAmount);
+    }
+
+    /**
+     *  @notice          Lets an authorized address mint an NFT to a recipient.
+     *  @dev             The logic in the `_canMint` function determines whether the caller is authorized to mint NFTs.
+     *
+     *  @param _to       The recipient of the NFT to mint.
+     *  @param _quantity The number of NFTs to mint.
+     */
+    function batchMintTo(address _to, uint256 _quantity) public payable virtual nonReentrant {
+        if (!_canMint()) {
+            revert ERC721BadgeNonTransferable_notAuthorized();
+        }
+
+        (address platformFeeRecipient, uint256 platformFeeAmount) = _checkPlatformFee();
+
+        string memory _baseURI = _getBaseURI(_nextTokenId());
+        _safeMint(_to, _quantity);
+
+        emit BatchMinted(_to, _quantity, _baseURI);
+
+        _payPlatformFee(platformFeeRecipient, platformFeeAmount * _quantity);
+    }
+
+    /**
+     *  @notice         Lets an owner or approved operator burn the NFT of the given tokenId.
+     *  @dev            ERC721A's `_burn(uint256,bool)` internally checks for token approvals.
+     *
+     *  @param _tokenId The tokenId of the NFT to burn.
+     */
+    function burn(uint256 _tokenId) external virtual {
+        _burn(_tokenId, true);
+    }
+
+    /// @notice The tokenId assigned to the next new NFT to be minted.
+    function nextTokenIdToMint() public view virtual returns (uint256) {
+        return _nextTokenId();
+    }
+
+    /// @notice Returns whether a given address is the owner, or approved to transfer an NFT.
+    function isApprovedOrOwner(address _operator, uint256 _tokenId)
+        public
+        view
+        virtual
+        returns (bool isApprovedOrOwnerOf)
+    {
+        address owner = ownerOf(_tokenId);
+        isApprovedOrOwnerOf =
+            (_operator == owner || isApprovedForAll(owner, _operator) || getApproved(_tokenId) == _operator);
+    }
+
+    /// @notice Returns whether a given token id has been minted
+    function exists(uint256 _tokenId) external virtual returns (bool) {
+        return _exists(_tokenId);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                        ERC-721A overrides
+    //////////////////////////////////////////////////////////////*/
+
+    /// @dev See {ERC721-setApprovalForAll}.
+    function setApprovalForAll(address operator, bool approved) public override(ERC721AUpgradeable) {
+        super.setApprovalForAll(operator, approved);
+    }
+
+    /// @dev See {ERC721-approve}.
+    function approve(address operator, uint256 tokenId) public payable override(ERC721AUpgradeable) {
+        super.approve(operator, tokenId);
+    }
+
+    /// @dev See {ERC721-_transferFrom}.
+    function transferFrom(address from, address to, uint256 tokenId) public payable override(ERC721AUpgradeable) {
+        revert ERC721BadgeNonTransferable.ERC721BadgeNonTransferable_nonTransferable();
+    }
+
+    /// @dev See {ERC721-_safeTransferFrom}.
+    function safeTransferFrom(address from, address to, uint256 tokenId) public payable override(ERC721AUpgradeable) {
+        revert ERC721BadgeNonTransferable.ERC721BadgeNonTransferable_nonTransferable();
+    }
+
+    /// @dev See {ERC721-_safeTransferFrom}.
+    function safeTransferFrom(address from, address to, uint256 tokenId, bytes memory data)
+        public
+        payable
+        override(ERC721AUpgradeable)
+    {
+        revert ERC721BadgeNonTransferable.ERC721BadgeNonTransferable_nonTransferable();
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                        Internal (overrideable) functions
+    //////////////////////////////////////////////////////////////*/
+
+    /// @dev Returns whether contract metadata can be set in the given execution context.
+    function _canSetBaseURI() internal view virtual returns (bool) {
+        return _hasRole(ADMIN_ROLE, msg.sender);
+    }
+
+    /// @dev Returns whether a token can be minted in the given execution context.
+    function _canMint() internal view virtual returns (bool) {
+        return _hasRole(ADMIN_ROLE, msg.sender) || _hasRole(MINTER_ROLE, msg.sender);
+    }
+
+    /// @dev Returns whether royalty info can be set in the given execution context.
+    function _canSetRoyaltyInfo() internal view virtual override returns (bool) {
+        return _hasRole(ADMIN_ROLE, msg.sender);
+    }
+
+    /// @dev Returns whether contract metadata can be set in the given execution context.
+    function _canSetContractURI() internal view virtual override returns (bool) {
+        return _hasRole(ADMIN_ROLE, msg.sender);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                        Internal (platform fee) functions
+    //////////////////////////////////////////////////////////////*/
+
+    function _checkPlatformFee() internal view returns (address recipient, uint256 amount) {
+        // don't charge platform fee if sender is a contract or globals address is not set
+        if (_isContract(msg.sender) || _getGlobalsAddress() == address(0)) {
+            return (address(0), 0);
+        }
+
+        (recipient, amount) = _platformFeeInfo(0);
+
+        // ensure the ether being sent was included in the transaction
+        if (amount > msg.value) {
+            revert CurrencyTransferLib.CurrencyTransferLib_insufficientValue();
+        }
+    }
+
+    function _payPlatformFee(address recipient, uint256 amount) internal {
+        if (amount == 0) {
+            return;
+        }
+
+        CurrencyTransferLib.safeTransferNativeToken(recipient, amount);
+
+        emit PaidPlatformFee(address(0), amount);
+    }
+
+    /**
+     * @dev derived from Openzepplin's address utils
+     *      https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v4.8.2/contracts/utils/Address.sol
+     */
+    function _isContract(address _account) internal view returns (bool) {
+        // This method relies on extcodesize/address.code.length, which returns 0
+        // for contracts in construction, since the code is only stored at the end
+        // of the constructor execution.
+
+        return _account.code.length > 0;
+    }
+}

--- a/src/tokens/ERC721/ERC721BadgeNonTransferableMock.sol
+++ b/src/tokens/ERC721/ERC721BadgeNonTransferableMock.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.16;
+
+import {ERC721BadgeNonTransferable} from "./ERC721BadgeNonTransferable.sol";
+
+contract ERC721BadgeNonTransferableMock is ERC721BadgeNonTransferable {
+    constructor(
+        string memory _name,
+        string memory _symbol,
+        address _royaltyReceiver,
+        uint16 _royaltyBPS,
+        bytes memory _data
+    ) ERC721BadgeNonTransferable(true) {
+        initialize(msg.sender, _name, _symbol, _royaltyReceiver, _royaltyBPS, _data);
+    }
+}

--- a/test/tokens/ERC721/ERC721BadgeNonTransferable.t.sol
+++ b/test/tokens/ERC721/ERC721BadgeNonTransferable.t.sol
@@ -1,0 +1,313 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.16;
+
+import "forge-std/Test.sol";
+import {IERC2981} from "@solidstate/contracts/interfaces/IERC2981.sol";
+import {IERC721} from "@solidstate/contracts/interfaces/IERC721.sol";
+import {ERC721BadgeNonTransferableMock} from "src/tokens/ERC721/ERC721BadgeNonTransferableMock.sol";
+import {ERC721BadgeNonTransferable} from "src/tokens/ERC721/ERC721BadgeNonTransferable.sol";
+import {IBatchMintMetadata} from "src/extensions/batchMintMetadata/IBatchMintMetadata.sol";
+
+uint256 constant MAX_INT = 2 ** 256 - 1;
+
+contract Setup is Test {
+    event UpdatedBaseURI(string baseURIForTokens);
+    event BatchMetadataUpdate(uint256 fromTokenId, uint256 toTokenId);
+
+    address creator = address(0x10);
+    address other = address(0x11);
+    address globals = address(0x12);
+
+    ERC721BadgeNonTransferableMock erc721Badge;
+
+    uint16 tenPercentBPS = 1000;
+    bytes32 constant ADMIN_ROLE = bytes32(uint256(0));
+    bytes32 constant MINTER_ROLE = bytes32(uint256(1));
+
+    // ipfs uri taken from https://docs.ipfs.tech/how-to/best-practices-for-nft-data/#types-of-ipfs-links-and-when-to-use-them
+    string baseURI = "ipfs://bafybeibnsoufr2renqzsh347nrx54wcubt5lgkeivez63xvivplfwhtpym/";
+
+    function setUp() public {
+        vm.prank(creator);
+        bytes memory data = abi.encode(address(0), address(0), baseURI);
+        erc721Badge = new ERC721BadgeNonTransferableMock("Name", "Symbol", creator, uint16(tenPercentBPS), data);
+
+        afterSetup();
+    }
+
+    // can override this function to perform further setup tasks
+    function afterSetup() public virtual {}
+}
+
+contract ERC721BadgeNonTransferable_initialise is Setup {
+    function test_initialise_correctly() public {
+        assertEq("Name", erc721Badge.name());
+        assertEq("Symbol", erc721Badge.symbol());
+        assertEq(creator, erc721Badge.owner());
+        assertEq(baseURI, erc721Badge.tokenURI(0));
+    }
+
+    function test_initialise_with_empty_string() public {
+        vm.prank(creator);
+
+        // global and minter address but baseTokenURI is an empty string
+        bytes memory data = abi.encode(address(0), address(0), "");
+
+        // initialises
+        ERC721BadgeNonTransferable emptyString = new ERC721BadgeNonTransferableMock("Name", "Symbol", creator, uint16(tenPercentBPS), data);
+
+        // but tokenURI reverts
+        vm.expectRevert(IBatchMintMetadata.BatchMintMetadata_invalidTokenId.selector);
+        emptyString.tokenURI(0);
+
+        // mintTo will revert also
+        vm.expectRevert();
+        emptyString.mintTo(creator);
+    }
+
+    function test_emits_updated_base_uri_event() public {
+        // global and minter address but baseTokenURI is an empty string
+        bytes memory data = abi.encode(address(0), address(0), baseURI);
+
+        vm.expectEmit(true, true, true, true);
+        emit UpdatedBaseURI(baseURI);
+
+        vm.prank(creator);
+        new ERC721BadgeNonTransferableMock("Name", "Symbol", creator, uint16(tenPercentBPS), data);
+    }
+
+    function test_should_revert_when_initialised_without_base_token_URI() public {
+        vm.prank(creator);
+        // global and minter address but no baseTokenURI in data
+        bytes memory data = abi.encode(address(0), address(0));
+        vm.expectRevert();
+        new ERC721BadgeNonTransferableMock("Name", "Symbol", creator, uint16(tenPercentBPS), data);
+    }
+}
+
+contract ERC721BadgeNonTransferable__setBaseURI is Setup {
+    string differentBaseURI = "some other url";
+
+    function test_set_base_uri_for_all_tokens() public {
+        vm.prank(creator);
+        erc721Badge.setBaseURI(differentBaseURI);
+
+        assertEq(differentBaseURI, erc721Badge.tokenURI(0));
+        assertEq(differentBaseURI, erc721Badge.tokenURI(MAX_INT - 1));
+    }
+
+    function test_set_base_uri_when_not_set_on_initialise() public {
+        // global and minter address but baseTokenURI is an empty string
+        bytes memory data = abi.encode(address(0), address(0), "");
+        vm.prank(creator);
+        ERC721BadgeNonTransferable erc721BadgeNoBaseURI = new ERC721BadgeNonTransferableMock("Name", "Symbol", creator, uint16(tenPercentBPS), data);
+
+        vm.prank(creator);
+        erc721BadgeNoBaseURI.setBaseURI(baseURI);
+
+        assertEq(baseURI, erc721Badge.tokenURI(0));
+        assertEq(baseURI, erc721Badge.tokenURI(MAX_INT - 1));
+    }
+
+    function test_emits_updated_base_uri_event() public {
+        vm.expectEmit(true, true, true, true);
+        emit UpdatedBaseURI(differentBaseURI);
+
+        vm.prank(creator);
+        erc721Badge.setBaseURI(differentBaseURI);
+    }
+
+    function test_reverts_when_access_is_invalid() public {
+        vm.expectRevert(ERC721BadgeNonTransferable.ERC721BadgeNonTransferable_notAuthorized.selector);
+        vm.prank(other);
+        erc721Badge.setBaseURI(differentBaseURI);
+    }
+}
+
+// Copied from lazymint
+
+contract ERC721BadgeNonTransferable__royaltyInfo is Setup {
+    function afterSetup() public override {
+        vm.prank(creator);
+        erc721Badge.mintTo(creator);
+    }
+
+    function test_gets_receiver_and_amount() public {
+        (address receiver, uint256 amount) = erc721Badge.royaltyInfo(0, 1 ether);
+        assertEq(receiver, creator);
+        assertEq(amount, 0.1 ether);
+    }
+
+    function test_supports_ERC2981_interface() public {
+        assertTrue(erc721Badge.supportsInterface(type(IERC2981).interfaceId));
+    }
+
+    function test_returns_token_specific_royalty_info() public {
+        uint16 fivePercentBPS = 500;
+
+        vm.prank(creator);
+        erc721Badge.setRoyaltyInfoForToken(0, other, fivePercentBPS);
+
+        (address receiver, uint256 amount) = erc721Badge.royaltyInfo(0, 1 ether);
+        assertEq(receiver, other);
+        assertEq(amount, 0.05 ether);
+    }
+}
+
+contract ERC721BadgeNonTransferable__grantRole is Setup {
+    function test_can_grant_admin_role() public {
+        vm.prank(creator);
+        erc721Badge.grantRole(ADMIN_ROLE, other);
+
+        vm.prank(other);
+        erc721Badge.mintTo(other);
+        assertEq(erc721Badge.ownerOf(0), other);
+    }
+
+    function test_can_grant_minter_role() public {
+        vm.prank(creator);
+        erc721Badge.grantRole(MINTER_ROLE, other);
+
+        vm.prank(other);
+        erc721Badge.mintTo(other);
+        assertEq(erc721Badge.ownerOf(0), other);
+    }
+}
+
+contract ERC721BadgeNonTransferable__revokeRole is Setup {
+    function afterSetup() public override {
+        vm.prank(creator);
+        erc721Badge.grantRole(MINTER_ROLE, other);
+    }
+
+    function test_can_revoke_role() public {
+        vm.prank(creator);
+        erc721Badge.revokeRole(MINTER_ROLE, other);
+
+        vm.expectRevert(ERC721BadgeNonTransferable.ERC721BadgeNonTransferable_notAuthorized.selector);
+        vm.prank(other);
+        erc721Badge.mintTo(other);
+    }
+
+    function test_reverts_if_not_admin() public {
+        vm.expectRevert();
+        vm.prank(other);
+        erc721Badge.revokeRole(MINTER_ROLE, other);
+    }
+}
+
+contract ERC721BadgeNonTransferable__mintTo is Setup {
+    function test_mints_to_address() public {
+        vm.prank(creator);
+        erc721Badge.mintTo(other);
+
+        assertEq(other, erc721Badge.ownerOf(0));
+    }
+
+    function test_reverts_if_not_authorised() public {
+        vm.expectRevert(ERC721BadgeNonTransferable.ERC721BadgeNonTransferable_notAuthorized.selector);
+        vm.prank(other);
+        erc721Badge.mintTo(other);
+    }
+}
+
+contract ERC721BadgeNonTransferable__batchMintTo is Setup {
+    function test_mints_multiple_to_address() public {
+        vm.prank(creator);
+        erc721Badge.batchMintTo(other, 3);
+
+        assertEq(other, erc721Badge.ownerOf(0));
+        assertEq(other, erc721Badge.ownerOf(1));
+        assertEq(other, erc721Badge.ownerOf(2));
+    }
+
+    function test_can_be_mixed_with_mintTo() public {
+        vm.prank(creator);
+        erc721Badge.mintTo(other);
+
+        vm.prank(creator);
+        erc721Badge.batchMintTo(other, 2);
+
+        assertEq(erc721Badge.tokenURI(0), baseURI);
+        assertEq(erc721Badge.tokenURI(1), baseURI);
+        assertEq(erc721Badge.tokenURI(2), baseURI);
+    }
+
+    function test_reverts_if_not_authorised() public {
+        vm.expectRevert(ERC721BadgeNonTransferable.ERC721BadgeNonTransferable_notAuthorized.selector);
+        vm.prank(other);
+        erc721Badge.batchMintTo(other, 2);
+    }
+}
+
+contract ERC721BadgeNonTransferable__burn is Setup {
+    function afterSetup() public override {
+        vm.prank(creator);
+        erc721Badge.mintTo(other);
+    }
+
+    function test_burns_token() public {
+        vm.prank(other);
+        erc721Badge.burn(0);
+
+        vm.expectRevert();
+        erc721Badge.ownerOf(0);
+    }
+}
+
+contract ERC721BadgeNonTransferable__setContractURI is Setup {
+    function test_sets_contract_uri() public {
+        vm.prank(creator);
+        erc721Badge.setContractURI(baseURI);
+
+        assertEq(baseURI, erc721Badge.contractURI());
+    }
+
+    function test_only_owner_can_set_contract_uri() public {
+        vm.prank(other);
+        vm.expectRevert();
+        erc721Badge.setContractURI(baseURI);
+    }
+}
+
+contract ERC721BadgeNonTransferable__owner is Setup {
+    function test_owner() public {
+        vm.prank(creator);
+        assertEq(creator, erc721Badge.owner());
+    }
+}
+
+contract ERC721BadgeNonTransferable__transferFrom is Setup {
+    function afterSetup() public override {
+        vm.prank(creator);
+        erc721Badge.mintTo(other);
+    }
+
+    function test_reverts_with_transfer_from() public {
+        vm.prank(other);
+        vm.expectRevert(ERC721BadgeNonTransferable.ERC721BadgeNonTransferable_nonTransferable.selector);
+        erc721Badge.transferFrom(other, creator, 0);
+    }
+
+    function test_reverts_with_safe_transfer_from() public {
+        vm.prank(other);
+        vm.expectRevert(ERC721BadgeNonTransferable.ERC721BadgeNonTransferable_nonTransferable.selector);
+        erc721Badge.safeTransferFrom(other, creator, 0);
+    }
+}
+
+contract ERC721BadgeNonTransferable__multicall is Setup {
+    function test_can_perform_multiple_calls_in_one_transaction() public {
+        bytes[] memory calls = new bytes[](2);
+        calls[0] = abi.encodeCall(erc721Badge.batchMintTo, (other, 2));
+        calls[1] = abi.encodeCall(erc721Badge.batchMintTo, (other, 2));
+
+        vm.prank(creator);
+        erc721Badge.multicall(calls);
+
+        assertEq(erc721Badge.ownerOf(0), other);
+        assertEq(erc721Badge.ownerOf(1), other);
+        assertEq(erc721Badge.ownerOf(2), other);
+        assertEq(erc721Badge.ownerOf(3), other);
+    }
+}


### PR DESCRIPTION
Adds new ERC721 implementation "ERC721BageNonTransferable" that is the same as badge except that `transferFrom` `safeTransferFrom` now revert with error `ERC721BadgeNonTransferable_nonTransferable`

To create a new ERC721BadgeNonTransferable contract call `createERC721WithTokenURI` with `"BadgeNonTransferable"` as the implementation Id.
https://github.com/open-format/contracts/blob/fea1f3d3ab7a428272d540bea20dd77ec7f8c7cf/scripts/facet/ERC721FactoryFacet.s.sol#L82

## Key differences from ERC721Badge contract

### Modified Transfer functions:
https://github.com/open-format/contracts/blob/fea1f3d3ab7a428272d540bea20dd77ec7f8c7cf/src/tokens/ERC721/ERC721BadgeNonTransferable.sol#L262-L279

### Contract version and name
https://github.com/open-format/contracts/blob/fea1f3d3ab7a428272d540bea20dd77ec7f8c7cf/src/tokens/ERC721/ERC721BadgeNonTransferable.sol#L26-L27
