### PR TITLE
Feature/of 750 add access control to contracts

### DIFF
--- a/scripts/facet/SettingsFacet.s.sol
+++ b/scripts/facet/SettingsFacet.s.sol
@@ -21,7 +21,7 @@ contract Deploy is Script, Utils {
         SettingsFacet settingsFacet = new SettingsFacet();
 
         // construct array of function selectors
-        bytes4[] memory selectors = new bytes4[](7);
+        bytes4[] memory selectors = new bytes4[](13);
         selectors[0] = settingsFacet.setApplicationFee.selector;
         selectors[1] = settingsFacet.setAcceptedCurrencies.selector;
         selectors[2] = settingsFacet.applicationFeeInfo.selector;
@@ -29,6 +29,12 @@ contract Deploy is Script, Utils {
         selectors[4] = settingsFacet.hasCreatorAccess.selector;
         selectors[5] = settingsFacet.platformFeeInfo.selector;
         selectors[6] = settingsFacet.getGlobalsAddress.selector;
+        selectors[7] = settingsFacet.enableAccessControl.selector;
+        selectors[8] = settingsFacet.grantRole.selector;
+        selectors[9] = settingsFacet.hasRole.selector;
+        selectors[10] = settingsFacet.getRoleAdmin.selector;
+        selectors[11] = settingsFacet.revokeRole.selector;
+        selectors[12] = settingsFacet.renounceRole.selector;
 
         // construct and ADD facet cut
         IDiamondWritableInternal.FacetCut[] memory cuts = new IDiamondWritableInternal.FacetCut[](1);

--- a/src/facet/SettingsFacet.sol
+++ b/src/facet/SettingsFacet.sol
@@ -2,13 +2,17 @@
 pragma solidity ^0.8.16;
 
 import {SafeOwnable, OwnableInternal} from "@solidstate/contracts/access/ownable/SafeOwnable.sol";
+import {AccessControl} from "@solidstate/contracts/access/access_control/AccessControl.sol";
 import {ApplicationFee} from "../extensions/applicationFee/ApplicationFee.sol";
 import {ApplicationAccess, IApplicationAccess} from "../extensions/applicationAccess/ApplicationAccess.sol";
 import {PlatformFee} from "../extensions/platformFee/PlatformFee.sol";
 import {IVersionable} from "../extensions/versionable/IVersionable.sol";
 
-string constant FACET_VERSION = "1.0.0";
+string constant FACET_VERSION = "1.1.0";
 string constant FACET_NAME = "SettingsFacet";
+
+bytes32 constant ADMIN_ROLE = bytes32(uint256(0));
+bytes32 constant OPERATOR_ROLE = bytes32(uint256(1));
 
 /**
  * @title   "Settings Facet"
@@ -17,7 +21,14 @@ string constant FACET_NAME = "SettingsFacet";
  *          which provide functionality for managing application and platform fees, ownership management, and restricted
  *          access to contract creation.
  */
-contract SettingsFacet is ApplicationFee, PlatformFee, SafeOwnable, ApplicationAccess, IVersionable {
+contract SettingsFacet is
+    ApplicationFee,
+    PlatformFee,
+    SafeOwnable,
+    AccessControl,
+    ApplicationAccess,
+    IVersionable
+    {
     /**
      * @dev Override to return facet version.
      * @return version This facet version.
@@ -84,5 +95,12 @@ contract SettingsFacet is ApplicationFee, PlatformFee, SafeOwnable, ApplicationA
      */
     function _transferOwnership(address account) internal override(OwnableInternal, SafeOwnable) {
         SafeOwnable._transferOwnership(account);
+    }
+
+    /**
+     * @dev enables access control by granting the owner the admin role.
+     */
+    function enableAccessControl() external onlyOwner() {
+        _grantRole(ADMIN_ROLE, _owner());
     }
 }

--- a/test/integration/facet/SettingsFacet.t.sol
+++ b/test/integration/facet/SettingsFacet.t.sol
@@ -16,8 +16,7 @@ import {Upgradable} from "src/proxy/upgradable/Upgradable.sol";
 import {RegistryMock} from "src/registry/RegistryMock.sol";
 import {AppFactory} from "src/factories/App.sol";
 import {Globals} from "src/globals/Globals.sol";
-
-import {SettingsFacet, IApplicationAccess} from "src/facet/SettingsFacet.sol";
+import {SettingsFacet, IApplicationAccess, ADMIN_ROLE, OPERATOR_ROLE} from "src/facet/SettingsFacet.sol";
 
 abstract contract Helpers {
     function prepareSingleFacetCut(
@@ -59,7 +58,7 @@ contract Setup is Test, Helpers {
         settingsFacet = new SettingsFacet();
 
         // add facet to registry
-        bytes4[] memory selectors = new bytes4[](7);
+        bytes4[] memory selectors = new bytes4[](13);
         selectors[0] = settingsFacet.setApplicationFee.selector;
         selectors[1] = settingsFacet.setAcceptedCurrencies.selector;
         selectors[2] = settingsFacet.applicationFeeInfo.selector;
@@ -67,6 +66,12 @@ contract Setup is Test, Helpers {
         selectors[4] = settingsFacet.hasCreatorAccess.selector;
         selectors[5] = settingsFacet.platformFeeInfo.selector;
         selectors[6] = settingsFacet.getGlobalsAddress.selector;
+        selectors[7] = settingsFacet.enableAccessControl.selector;
+        selectors[8] = settingsFacet.grantRole.selector;
+        selectors[9] = settingsFacet.hasRole.selector;
+        selectors[10] = settingsFacet.getRoleAdmin.selector;
+        selectors[11] = settingsFacet.revokeRole.selector;
+        selectors[12] = settingsFacet.renounceRole.selector;
 
         registry.diamondCut(
             prepareSingleFacetCut(address(settingsFacet), IDiamondWritableInternal.FacetCutAction.ADD, selectors),
@@ -244,5 +249,50 @@ contract SettingsFacet__integration_platformFeeInfo is Setup {
 
         assertEq(recipient, other);
         assertEq(amount, 1 ether);
+    }
+}
+
+contract SettingsFacet__intergration_enableAccessControl is Setup {
+    function test_can_enable_access_control() public {
+        vm.prank(appOwner);
+        SettingsFacet(address(app)).enableAccessControl();
+
+        assertTrue(
+            SettingsFacet(address(app)).hasRole(ADMIN_ROLE, appOwner)
+        );
+    }
+
+    function test_reverts_if_not_app_owner() public {
+        vm.prank(other);
+        vm.expectRevert(IOwnableInternal.Ownable__NotOwner.selector);
+        SettingsFacet(address(app)).enableAccessControl();
+    }
+}
+
+
+contract SettingsFacet__intergration_grantRole is Setup {
+    function test_can_grant_operator_role() public {
+        vm.prank(appOwner);
+        SettingsFacet(address(app)).enableAccessControl();
+
+        vm.prank(appOwner);
+        SettingsFacet(address(app)).grantRole(OPERATOR_ROLE, other);
+        assertTrue(SettingsFacet(address(app)).hasRole(OPERATOR_ROLE, other));
+    }
+
+    function test_reverts_if_not_app_owner() public {
+        vm.prank(appOwner);
+        SettingsFacet(address(app)).enableAccessControl();
+
+        vm.prank(other);
+        vm.expectRevert(
+                abi.encodePacked(
+                    'AccessControl: account ',
+                    vm.toString(other),
+                    ' is missing role ',
+                    vm.toString(ADMIN_ROLE)
+                )
+            );
+        SettingsFacet(address(app)).grantRole(OPERATOR_ROLE, other);
     }
 }


### PR DESCRIPTION
- Adds solid state access control to settings facet
- Adds checks for owner, admin and operator roles in reward facet functions
- Removed unnecessary minter check on reward facet functions as token contracts will revert 

The flow will be:
1. app owner calls `enableAccessControl` on the app contract
2. app owner grants admin or operator roles on the contracts by calling `grantRole` function
3. operator then calls the rewards facet functions

As long as the permissions on the tokens have approved the app as a spender/minter this will allow operators to control the rewarding of the app

Owners can revoke roles using the `revokeRole` function

I have opted for a function to enable access control on individual app contracts. This is because we use safe ownable on the apps already and the modified diamond pattern means we cannot update the apps storage on update.