### PR TITLE
Feature/of 599 get all contract deployments aligned

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,8 @@ deploy-ERC721FactoryFacet:; forge script scripts/facet/ERC721FactoryFacet.s.sol:
 deploy-ERC20FactoryFacet:; forge script scripts/facet/ERC20FactoryFacet.s.sol:Deploy --rpc-url $(rpc) --broadcast $(verbose) $(gasPrice) $(legacy) $(slow)
 deploy-ERC721LazyDropFacet:; forge script scripts/facet/ERC721LazyDropFacet.s.sol:Deploy --rpc-url $(rpc) --broadcast $(verbose) $(gasPrice) $(legacy) $(slow)
 
+redeploy-AllFacets:; forge script scripts/facet/AllFacets.s.sol:RedeployAllFacets --rpc-url $(rpc) --broadcast $(verbose) $(gasPrice) $(legacy) $(slow)
+
 # patch
 patch-SettingsFacet:; forge script scripts/facet/SettingsFacet.s.sol:Patch --rpc-url $(rpc) --broadcast $(verbose) $(legacy) $(slow)
 

--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,17 @@ RewardsFacet.batchMintBadge:; forge script \
 	--sig "run(address)" \
  	--rpc-url $(rpc) --broadcast $(verbose) $(legacy) $(slow) $(args)
 
+# example: make SettingsFacet.enableAccessControl
+SettingsFacet.enableAccessControl:; forge script \
+	scripts/facet/SettingsFacet.s.sol:EnableAccessControl \
+ 	--rpc-url $(rpc) --broadcast $(verbose) $(legacy) $(slow) $(args)
+
+# example: make SettingsFacet.grantRoleOperator args="0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"
+SettingsFacet.grantRoleOperator:; forge script \
+	scripts/facet/SettingsFacet.s.sol:GrantRoleOperator \
+	--sig "run(address)" \
+ 	--rpc-url $(rpc) --broadcast $(verbose) $(legacy) $(slow) $(args)
+
 # Simulate create new app and issues rewards
 # example: make SimulateAppAndRewards rpc="anvil" args="appName"
 SimulateAppAndRewards:; forge script \
@@ -205,6 +216,16 @@ update-ERC20FactoryFacet:; forge script scripts/facet/ERC20FactoryFacet.s.sol:Up
 
 update-RewardsFacet:; forge script scripts/facet/RewardsFacet.s.sol:Update --rpc-url $(rpc) --broadcast $(verbose) $(legacy) $(slow)
 update-ERC20Base:; forge script scripts/tokens/ERC20Base.s.sol:Update --rpc-url $(rpc) --broadcast $(verbose) $(legacy) $(slow)
+
+# Add access control
+# Date 07.03.25
+# updates SettingsFacet and RewardsFacet to add access control to apps
+# PR #155 https://github.com/open-format/contracts/pull/155
+update-AddAccessControl:; make \
+	update-RewardsFacet \
+	update-SettingsFacet-addAccessControl
+
+update-SettingsFacet-addAccessControl:; forge script scripts/facet/SettingsFacet.s.sol:Update_AddAccessControl --rpc-url $(rpc) --broadcast $(verbose) $(legacy) $(slow)
 
 # Add badge minting functionality
 # Date 20.05.24

--- a/deployed/421614-staging.json
+++ b/deployed/421614-staging.json
@@ -4,16 +4,16 @@
     "startBlock": 53181340
   },
   "ChargeFacet": {
-    "address": "0x87d62B44557F731c5B9D93fbBa096928Fb382799",
-    "startBlock": 67933710
+    "address": "0x4B234fe1499d63DBA7937a990D73A7D885f28405",
+    "startBlock": 7874111
   },
   "ERC20Base": {
     "address": "0x6F36f7A3CD912F284bc13f85ee04c57Da14319c1",
     "startBlock": 53181398
   },
   "ERC20FactoryFacet": {
-    "address": "0x2C227862Be6F0B1A6fd398E0630A60C09B34A077",
-    "startBlock": 53195102
+    "address": "0xAB2c0a77E4a84ac6Fd669a11784a644CFEd1f93D",
+    "startBlock": 7874111
   },
   "ERC20Point": {
     "address": "0x81c44F762785dD26FC94E4c549B872E9FE19c2dD",
@@ -28,12 +28,12 @@
     "startBlock": 53193947
   },
   "ERC721FactoryFacet": {
-    "address": "0x9147Deb9D788e86b98757a16269a9d033974BfA3",
-    "startBlock": 53194675
+    "address": "0xb5b32F47500d9f7F589eD446817fB4637F411F8c",
+    "startBlock": 7874111
   },
   "ERC721LazyDropFacet": {
-    "address": "0x24FEdc64981C3ccD789AF7e695e3070Dc7006389",
-    "startBlock": 53195338
+    "address": "0xEBD73dB378Fc0e95DF3C8D4149F34742a0aaa666",
+    "startBlock": 7874111
   },
   "ERC721LazyMint": {
     "address": "0x937bb2985eE71F62360E9c3AB88B54822Af248a3",
@@ -60,12 +60,12 @@
     "startBlock": 53180881
   },
   "RewardFacet": {
-    "address": "0x13dd8f63A9452adEA3f2152B12a13563AC433c41",
-    "startBlock": 85607165
+    "address": "0xd1b3fBb731FE7235344973247D88c61d17686E26",
+    "startBlock": 7874111
   },
   "SettingsFacet": {
-    "address": "0xe0aaaf2A2F05DbE1feDa6aA6336fF2533D079BF0",
-    "startBlock": 53194585
+    "address": "0x00226ca6D7b9ac91aa4d22CEb873F18381Fc59ea",
+    "startBlock": 7874111
   },
   "XP": {
     "address": "0x77507D3F8727e640f469b41DaebBC767De055b16",

--- a/deployed/421614-staging.versions.json
+++ b/deployed/421614-staging.versions.json
@@ -1,36 +1,36 @@
 {
   "Facets": {
     "ChargeFacet": {
-      "address": "0x87d62B44557F731c5B9D93fbBa096928Fb382799",
+      "address": "0x4B234fe1499d63DBA7937a990D73A7D885f28405",
       "selectors": [
         "0x10c3db96",
-        "0x20ecd1ec",
         "0x23d3a539",
-        "0x9eaa34ec"
+        "0x9eaa34ec",
+        "0x20ecd1ec"
       ],
-      "version": "0.0.0"
+      "version": "1.0.0"
     },
     "ERC20FactoryFacet": {
-      "address": "0x2C227862Be6F0B1A6fd398E0630A60C09B34A077",
+      "address": "0xAB2c0a77E4a84ac6Fd669a11784a644CFEd1f93D",
       "selectors": [
         "0x2d4105d1",
         "0x3cb20d6c",
         "0x08721a2c"
       ],
-      "version": "0.0.0"
+      "version": "1.0.0"
     },
     "ERC721FactoryFacet": {
-      "address": "0x9147Deb9D788e86b98757a16269a9d033974BfA3",
+      "address": "0xb5b32F47500d9f7F589eD446817fB4637F411F8c",
       "selectors": [
         "0xee4506f5",
         "0x4fc06be4",
         "0x851ba287",
         "0x0667aad5"
       ],
-      "version": "0.0.0"
+      "version": "1.0.0"
     },
     "ERC721LazyDropFacet": {
-      "address": "0x24FEdc64981C3ccD789AF7e695e3070Dc7006389",
+      "address": "0xEBD73dB378Fc0e95DF3C8D4149F34742a0aaa666",
       "selectors": [
         "0x225a2b3e",
         "0xd9854a88",
@@ -38,7 +38,7 @@
         "0x22ba9456",
         "0x70ad0183"
       ],
-      "version": "0.0.0"
+      "version": "1.0.0"
     },
     "Registry": {
       "address": "0x11cd7aB1B36674a1f41BD19Bbc9e15EaAaF9857F",
@@ -58,8 +58,8 @@
       ],
       "version": "-"
     },
-    "RewardFacet": {
-      "address": "0x13dd8f63A9452adEA3f2152B12a13563AC433c41",
+    "RewardsFacet": {
+      "address": "0xd1b3fBb731FE7235344973247D88c61d17686E26",
       "selectors": [
         "0x609512c9",
         "0xbdebfec5",
@@ -69,10 +69,10 @@
         "0xa6c130fc",
         "0xb92bafd6"
       ],
-      "version": "0.0.0"
+      "version": "1.1.0"
     },
     "SettingsFacet": {
-      "address": "0xe0aaaf2A2F05DbE1feDa6aA6336fF2533D079BF0",
+      "address": "0x00226ca6D7b9ac91aa4d22CEb873F18381Fc59ea",
       "selectors": [
         "0x561c4fc4",
         "0xf2c9caa2",
@@ -80,9 +80,15 @@
         "0xba4e4840",
         "0xacf8569a",
         "0x114ee370",
-        "0xf030f12e"
+        "0xf030f12e",
+        "0x36f5f45e",
+        "0x2f2ff15d",
+        "0x91d14854",
+        "0x248a9ca3",
+        "0xd547741f",
+        "0x8bb9c5bf"
       ],
-      "version": "0.0.0"
+      "version": "1.1.0"
     }
   }
 }

--- a/deployed/421614.json
+++ b/deployed/421614.json
@@ -3,6 +3,10 @@
     "address": "0x19781Af95cA4E113D5D1412452225D11A84ce992",
     "startBlock": 32647240
   },
+  "ChargeFacet": {
+    "address": "0xb9f76D7E2c1ee440Cb735e39FE7b00ece3CdA195",
+    "startBlock": 7874568
+  },
   "ConstellationFactory": {
     "address": "0x1890ED30698C70932fD784fA80aC9b161854b3Ed",
     "startBlock": 32298423
@@ -12,8 +16,8 @@
     "startBlock": 32647290
   },
   "ERC20FactoryFacet": {
-    "address": "0xAdbbCC5B721F83b0fE349AB82D4fCC68AaCDFAC3",
-    "startBlock": 32647834
+    "address": "0xb51e20A54d001706a268559c5531fC72d03A66EA",
+    "startBlock": 7874568
   },
   "ERC20Point": {
     "address": "0x7CCf50eD9E278E80E6C050c08aEC37E4c0d58f10",
@@ -28,12 +32,12 @@
     "startBlock": 32647374
   },
   "ERC721FactoryFacet": {
-    "address": "0xeCAa77Ff32cfB4913f59a21Ed07D81E448209960",
-    "startBlock": 61035224
+    "address": "0x55638A90f7068931D5d14456f181D72732a2005E",
+    "startBlock": 7874568
   },
   "ERC721LazyDropFacet": {
-    "address": "0x7E12434F0d9880957f67fF0Ce9c0F5ca83bdBD88",
-    "startBlock": 32647918
+    "address": "0x07B63f6DB2d9190c3cc10939abC41a8F60481a4e",
+    "startBlock": 7874568
   },
   "ERC721LazyMint": {
     "address": "0xC7178D6d724068E8D6778dD5a9b94175c71D5b39",
@@ -60,12 +64,12 @@
     "startBlock": 32647137
   },
   "RewardFacet": {
-    "address": "0x5D558E68b32E6f416b09d639B601f6eE8729Fbc7",
-    "startBlock": 87103667
+    "address": "0xC56498Fe63622b2266e581a294103c386bA2d30e",
+    "startBlock": 7874568
   },
   "SettingsFacet": {
-    "address": "0xA09a42BbA9Ba0bF06dFE3ED77a0086C7Ee831163",
-    "startBlock": 32647655
+    "address": "0xcB563CbB6b199b5c81CE8a5036eb2Aef81c15Ffe",
+    "startBlock": 7874568
   },
   "StarFactory": {
     "address": "0xfa286f52075bCc6EE9716a765f8928762B3CD2d6",
@@ -94,6 +98,7 @@
     "Open_Format_App",
     "XP",
     "OFT",
-    "ERC20Point"
+    "ERC20Point",
+    "ChargeFacet"
   ]
 }

--- a/deployed/421614.versions.json
+++ b/deployed/421614.versions.json
@@ -1,26 +1,36 @@
 {
   "Facets": {
+    "ChargeFacet": {
+      "address": "0xb9f76D7E2c1ee440Cb735e39FE7b00ece3CdA195",
+      "selectors": [
+        "0x10c3db96",
+        "0x23d3a539",
+        "0x9eaa34ec",
+        "0x20ecd1ec"
+      ],
+      "version": "1.0.0"
+    },
     "ERC20FactoryFacet": {
-      "address": "0xAdbbCC5B721F83b0fE349AB82D4fCC68AaCDFAC3",
+      "address": "0xb51e20A54d001706a268559c5531fC72d03A66EA",
       "selectors": [
         "0x2d4105d1",
         "0x3cb20d6c",
         "0x08721a2c"
       ],
-      "version": "0.0.0"
+      "version": "1.0.0"
     },
     "ERC721FactoryFacet": {
-      "address": "0xeCAa77Ff32cfB4913f59a21Ed07D81E448209960",
+      "address": "0x55638A90f7068931D5d14456f181D72732a2005E",
       "selectors": [
         "0xee4506f5",
+        "0x4fc06be4",
         "0x851ba287",
-        "0x0667aad5",
-        "0x4fc06be4"
+        "0x0667aad5"
       ],
-      "version": "0.0.0"
+      "version": "1.0.0"
     },
     "ERC721LazyDropFacet": {
-      "address": "0x7E12434F0d9880957f67fF0Ce9c0F5ca83bdBD88",
+      "address": "0x07B63f6DB2d9190c3cc10939abC41a8F60481a4e",
       "selectors": [
         "0x225a2b3e",
         "0xd9854a88",
@@ -28,7 +38,7 @@
         "0x22ba9456",
         "0x70ad0183"
       ],
-      "version": "0.0.0"
+      "version": "1.0.0"
     },
     "Registry": {
       "address": "0xcD288D67b371AB590962B2bd8FEd9866d8d6C69d",
@@ -48,8 +58,8 @@
       ],
       "version": "-"
     },
-    "RewardFacet": {
-      "address": "0x5D558E68b32E6f416b09d639B601f6eE8729Fbc7",
+    "RewardsFacet": {
+      "address": "0xC56498Fe63622b2266e581a294103c386bA2d30e",
       "selectors": [
         "0x609512c9",
         "0xbdebfec5",
@@ -59,10 +69,10 @@
         "0xa6c130fc",
         "0xb92bafd6"
       ],
-      "version": "0.0.0"
+      "version": "1.1.0"
     },
     "SettingsFacet": {
-      "address": "0xA09a42BbA9Ba0bF06dFE3ED77a0086C7Ee831163",
+      "address": "0xcB563CbB6b199b5c81CE8a5036eb2Aef81c15Ffe",
       "selectors": [
         "0x561c4fc4",
         "0xf2c9caa2",
@@ -70,9 +80,15 @@
         "0xba4e4840",
         "0xacf8569a",
         "0x114ee370",
-        "0xf030f12e"
+        "0xf030f12e",
+        "0x36f5f45e",
+        "0x2f2ff15d",
+        "0x91d14854",
+        "0x248a9ca3",
+        "0xd547741f",
+        "0x8bb9c5bf"
       ],
-      "version": "0.0.0"
+      "version": "1.1.0"
     }
   }
 }

--- a/scripts/facet/AllFacets.s.sol
+++ b/scripts/facet/AllFacets.s.sol
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.16;
+
+import "forge-std/Script.sol";
+import {Utils} from "scripts/utils/Utils.sol";
+import {CONTRACT_NAME as REGISTRY} from "scripts/core/Registry.s.sol";
+import {
+    IDiamondWritable,
+    IDiamondWritableInternal
+} from "@solidstate/contracts/proxy/diamond/writable/IDiamondWritable.sol";
+import {Deployer as DeployerRewardsFacet} from "./RewardsFacet.s.sol";
+import {Deployer as DeployerSettingsFacet} from "./SettingsFacet.s.sol";
+import {Deployer as DeployerERC721FactoryFacet} from "./ERC721FactoryFacet.s.sol";
+import {Deployer as DeployerERC721LazyDropFacet} from "./ERC721LazyDropFacet.s.sol";
+import {Deployer as DeployerERC20FactoryFacet} from "./ERC20FactoryFacet.s.sol";
+import {Deployer as DeployerChargeFacet} from "./ChargeFacet.s.sol";
+import {IDeployer} from "./IDeployer.sol";
+
+/**
+ * Redeploys all the facet contracts
+ * This script will first deploy new facet contracts, then calls an update transaction
+ * known as a "diamond cut" that removes all existing facets and adds the newly deployed ones
+ * to the registry contract.
+ */
+contract RedeployAllFacets is Script, Utils {
+    /**
+     * Will broadcast transactions and export contract addresses to deployed/<chain-id>.json
+     */
+    function run() external {
+      address registryAddress = getContractDeploymentAddress(REGISTRY);
+      _run(registryAddress, false);
+    }
+
+    /**
+     * Will not broadcast any transactions so vm.prank can be used
+     */
+    function runTest(address registryAddress) external {
+      _run(registryAddress, true);
+    }
+
+    function _run(address registryAddress, bool isTest) internal {
+
+      // Initiate deployer scripts for all facets
+      address[] memory deployers = new address[](6);
+      deployers[0] = address(new DeployerRewardsFacet());
+      deployers[1] = address(new DeployerSettingsFacet());
+      deployers[2] = address(new DeployerERC721LazyDropFacet());
+      deployers[3] = address(new DeployerERC721FactoryFacet());
+      deployers[4] = address(new DeployerERC20FactoryFacet());
+      deployers[5] = address(new DeployerChargeFacet());
+
+      address[] memory facets = new address[](6);
+      {
+        // Deploy All facets contracts
+        if (isTest){
+          for (uint256 i = 0; i < deployers.length; i++) {
+            facets[i] = IDeployer(deployers[i]).deployTest();
+          }
+        } else {
+          for (uint256 i = 0; i < deployers.length; i++) {
+            facets[i] = IDeployer(deployers[i]).deploy();
+            IDeployer(deployers[i]).export();
+          }
+        }
+      }
+
+      // Perform a diamond cut that removes all facets then adds them back using the new deployment addresses
+      {
+        // Construct Diamond cut with new facets
+        uint256 facetsToAdd = 6;
+        IDiamondWritableInternal.FacetCut[] memory removeCuts = getRemoveCuts(registryAddress);
+        IDiamondWritableInternal.FacetCut[] memory cuts = new IDiamondWritableInternal.FacetCut[](removeCuts.length + facetsToAdd);
+
+        // Add cuts to `remove` all existing facets
+        for (uint256 i = 0; i < removeCuts.length; i++){
+          cuts[i] = removeCuts[i];
+        }
+
+        // Add cut to `add` each newly deployed facet
+        for (uint256 i = 0; i < facets.length; i++) {
+          cuts[removeCuts.length + i] = facetCutAdd(facets[i], IDeployer(deployers[i]).selectors());
+        }
+
+        // Perform the diamond cut
+        if (isTest){
+          // Use the default msg.sender in foundry tests
+          // https://book.getfoundry.sh/reference/config/testing?highlight=0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38#sender
+          vm.prank(address(0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38));
+          IDiamondWritable(payable(registryAddress)).diamondCut(cuts, address(0), "");
+        } else {
+          uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+          address deployerAddress = vm.addr(deployerPrivateKey);
+          vm.startBroadcast(deployerPrivateKey);
+          IDiamondWritable(payable(registryAddress)).diamondCut(cuts, address(0), "");
+          vm.stopBroadcast();
+        }
+      }
+    }
+}
+
+contract RemoveAllFacets is Script, Utils {
+    function run() external {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        address deployerAddress = vm.addr(deployerPrivateKey);
+
+        address registryAddress = getContractDeploymentAddress(REGISTRY);
+        IDiamondWritableInternal.FacetCut[] memory removeCuts = getRemoveCuts(registryAddress);
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        IDiamondWritable(payable(registryAddress)).diamondCut(removeCuts, address(0), "");
+
+        vm.stopBroadcast();
+    }
+}

--- a/scripts/facet/ChargeFacet.s.sol
+++ b/scripts/facet/ChargeFacet.s.sol
@@ -7,10 +7,46 @@ import {
     IDiamondWritableInternal
 } from "@solidstate/contracts/proxy/diamond/writable/IDiamondWritable.sol";
 import {Utils} from "scripts/utils/Utils.sol";
-import {ChargeFacet} from "src/facet/ChargeFacet.sol";
+import {ChargeFacet, Charge} from "src/facet/ChargeFacet.sol";
 import {RegistryMock} from "src/registry/RegistryMock.sol";
+import {IDeployer} from "./IDeployer.sol";
 
 string constant CONTRACT_NAME = "ChargeFacet";
+
+contract Deployer is IDeployer, Script, Utils {
+    address private addr;
+    uint256 private blockNumber;
+
+    function deploy() external returns (address) {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        vm.startBroadcast(deployerPrivateKey);
+        address chargeFacet = address(new ChargeFacet());
+        vm.stopBroadcast();
+
+        addr = chargeFacet;
+        blockNumber = block.number;
+
+        return chargeFacet;
+    }
+
+    function deployTest() external returns (address) {
+        return address(new ChargeFacet());
+    }
+
+    function export() external {
+        exportContractDeployment(CONTRACT_NAME, addr, blockNumber);
+    }
+
+    function selectors () external returns (bytes4[] memory){
+        bytes4[] memory s = new bytes4[](4);
+        s[0] = Charge.chargeUser.selector;
+        s[1] = Charge.setRequiredTokenBalance.selector;
+        s[2] = Charge.getRequiredTokenBalance.selector;
+        s[3] = Charge.hasFunds.selector;
+
+        return s;
+    }
+}
 
 contract Deploy is Script, Utils {
     function run() external {

--- a/scripts/facet/ERC20FactoryFacet.s.sol
+++ b/scripts/facet/ERC20FactoryFacet.s.sol
@@ -7,10 +7,45 @@ import {
     IDiamondWritableInternal
 } from "@solidstate/contracts/proxy/diamond/writable/IDiamondWritable.sol";
 import {Utils} from "scripts/utils/Utils.sol";
-import {ERC20FactoryFacet} from "src/facet/ERC20FactoryFacet.sol";
+import {ERC20FactoryFacet, ERC20Factory} from "src/facet/ERC20FactoryFacet.sol";
 import {RegistryMock} from "src/registry/RegistryMock.sol";
+import {IDeployer} from "./IDeployer.sol";
 
 string constant CONTRACT_NAME = "ERC20FactoryFacet";
+
+contract Deployer is IDeployer, Script, Utils {
+    address private addr;
+    uint256 private blockNumber;
+
+    function deploy() external returns (address) {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        vm.startBroadcast(deployerPrivateKey);
+        address erc20FactoryFacet = address(new ERC20FactoryFacet());
+        vm.stopBroadcast();
+
+        addr = erc20FactoryFacet;
+        blockNumber = block.number;
+
+        return erc20FactoryFacet;
+    }
+
+    function deployTest() external returns (address) {
+        return address(new ERC20FactoryFacet());
+    }
+
+    function export() external {
+        exportContractDeployment(CONTRACT_NAME, addr, blockNumber);
+    }
+
+    function selectors () external returns (bytes4[] memory){
+        bytes4[] memory s = new bytes4[](3);
+        s[0] = ERC20Factory.createERC20.selector;
+        s[1] = ERC20Factory.getERC20FactoryImplementation.selector;
+        s[2] = ERC20Factory.calculateERC20FactoryDeploymentAddress.selector;
+
+        return s;
+    }
+}
 
 contract Deploy is Script, Utils {
     function run() external {

--- a/scripts/facet/ERC721FactoryFacet.s.sol
+++ b/scripts/facet/ERC721FactoryFacet.s.sol
@@ -8,10 +8,46 @@ import {
     IDiamondWritableInternal
 } from "@solidstate/contracts/proxy/diamond/writable/IDiamondWritable.sol";
 import {Utils} from "scripts/utils/Utils.sol";
-import {ERC721FactoryFacet} from "src/facet/ERC721FactoryFacet.sol";
+import {ERC721FactoryFacet, ERC721Factory} from "src/facet/ERC721FactoryFacet.sol";
 import {RegistryMock} from "src/registry/RegistryMock.sol";
+import {IDeployer} from "./IDeployer.sol";
 
 string constant CONTRACT_NAME = "ERC721FactoryFacet";
+
+contract Deployer is IDeployer, Script, Utils {
+    address private addr;
+    uint256 private blockNumber;
+
+    function deploy() external returns (address) {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        vm.startBroadcast(deployerPrivateKey);
+        address erc721FactoryFacet = address(new ERC721FactoryFacet());
+        vm.stopBroadcast();
+
+        addr = erc721FactoryFacet;
+        blockNumber = block.number;
+
+        return erc721FactoryFacet;
+    }
+
+    function deployTest() external returns (address) {
+        return address(new ERC721FactoryFacet());
+    }
+
+    function export() external {
+        exportContractDeployment(CONTRACT_NAME, addr, blockNumber);
+    }
+
+    function selectors () external returns (bytes4[] memory){
+        bytes4[] memory s = new bytes4[](4);
+        s[0] = ERC721Factory.createERC721.selector;
+        s[1] = ERC721Factory.createERC721WithTokenURI.selector;
+        s[2] = ERC721Factory.getERC721FactoryImplementation.selector;
+        s[3] = ERC721Factory.calculateERC721FactoryDeploymentAddress.selector;
+
+        return s;
+    }
+}
 
 contract Deploy is Script, Utils {
     function run() external {

--- a/scripts/facet/ERC721LazyDropFacet.s.sol
+++ b/scripts/facet/ERC721LazyDropFacet.s.sol
@@ -7,10 +7,47 @@ import {
     IDiamondWritableInternal
 } from "@solidstate/contracts/proxy/diamond/writable/IDiamondWritable.sol";
 import {Utils} from "scripts/utils/Utils.sol";
-import {ERC721LazyDropFacet} from "src/facet/ERC721LazyDropFacet.sol";
+import {ERC721LazyDropFacet, ERC721LazyDrop} from "src/facet/ERC721LazyDropFacet.sol";
 import {RegistryMock} from "src/registry/RegistryMock.sol";
+import {IDeployer} from "./IDeployer.sol";
 
 string constant CONTRACT_NAME = "ERC721LazyDropFacet";
+
+contract Deployer is IDeployer, Script, Utils {
+    address private addr;
+    uint256 private blockNumber;
+
+    function deploy() external returns (address) {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        vm.startBroadcast(deployerPrivateKey);
+        address erc721LazyDropFacet = address(new ERC721LazyDropFacet());
+        vm.stopBroadcast();
+
+        addr = erc721LazyDropFacet;
+        blockNumber = block.number;
+
+        return erc721LazyDropFacet;
+    }
+
+    function deployTest() external returns (address) {
+        return address(new ERC721LazyDropFacet());
+    }
+
+    function export() external {
+        exportContractDeployment(CONTRACT_NAME, addr, blockNumber);
+    }
+
+    function selectors () external returns (bytes4[] memory){
+        bytes4[] memory s = new bytes4[](5);
+        s[0] = ERC721LazyDrop.ERC721LazyDrop_getClaimCondition.selector;
+        s[1] = ERC721LazyDrop.ERC721LazyDrop_verifyClaim.selector;
+        s[2] = ERC721LazyDrop.ERC721LazyDrop_claim.selector;
+        s[3] = ERC721LazyDrop.ERC721LazyDrop_setClaimCondition.selector;
+        s[4] = ERC721LazyDrop.ERC721LazyDrop_removeClaimCondition.selector;
+
+        return s;
+    }
+}
 
 contract Deploy is Script, Utils {
     function run() external {

--- a/scripts/facet/IDeployer.sol
+++ b/scripts/facet/IDeployer.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.16;
+
+interface IDeployer {
+  function deploy() external returns (address);
+  function deployTest() external returns (address);
+  function export() external;
+  function selectors() external returns (bytes4[] memory);
+}

--- a/scripts/facet/SettingsFacet.s.sol
+++ b/scripts/facet/SettingsFacet.s.sol
@@ -7,10 +7,55 @@ import {
     IDiamondWritableInternal
 } from "@solidstate/contracts/proxy/diamond/writable/IDiamondWritable.sol";
 import {Utils} from "scripts/utils/Utils.sol";
-import {SettingsFacet, OPERATOR_ROLE} from "src/facet/SettingsFacet.sol";
+import {SettingsFacet, OPERATOR_ROLE, AccessControl, ApplicationFee, PlatformFee} from "src/facet/SettingsFacet.sol";
 import {RegistryMock} from "src/registry/RegistryMock.sol";
+import {IDeployer} from "./IDeployer.sol";
 
 string constant CONTRACT_NAME = "SettingsFacet";
+
+contract Deployer is IDeployer, Script, Utils {
+    address private addr;
+    uint256 private blockNumber;
+
+    function deploy() external returns (address) {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        vm.startBroadcast(deployerPrivateKey);
+        address settingsFacet = address(new SettingsFacet());
+        vm.stopBroadcast();
+
+        addr = settingsFacet;
+        blockNumber = block.number;
+
+        return settingsFacet;
+    }
+
+    function deployTest() external returns (address) {
+        return address(new SettingsFacet());
+    }
+
+    function export() external {
+        exportContractDeployment(CONTRACT_NAME, addr, blockNumber);
+    }
+
+    function selectors () external returns (bytes4[] memory){
+        bytes4[] memory s = new bytes4[](13);
+        s[0] = SettingsFacet.setApplicationFee.selector;
+        s[1] = SettingsFacet.setAcceptedCurrencies.selector;
+        s[2] = ApplicationFee.applicationFeeInfo.selector;
+        s[3] = SettingsFacet.setCreatorAccess.selector;
+        s[4] = SettingsFacet.hasCreatorAccess.selector;
+        s[5] = PlatformFee.platformFeeInfo.selector;
+        s[6] = SettingsFacet.getGlobalsAddress.selector;
+        s[7] = SettingsFacet.enableAccessControl.selector;
+        s[8] = AccessControl.grantRole.selector;
+        s[9] = AccessControl.hasRole.selector;
+        s[10] = AccessControl.getRoleAdmin.selector;
+        s[11] = AccessControl.revokeRole.selector;
+        s[12] = AccessControl.renounceRole.selector;
+
+        return s;
+    }
+}
 
 contract Deploy is Script, Utils {
     function run() external {


### PR DESCRIPTION
- adds deployment scripts for access control
- adds a script to redeploy all facets, removing old ones

So far deployments have only been made to:
- [x] arbitrum sepolia staging
- [x] arbirtum sepolia

*will carry out all other chains after review.*

## Redploy All Facets script
The script `scripts/facet/AllFacets.s.sol` will be used on all chains to update everything. It uses a different deployment flow, first it deploys all facet contracts then constructs one diamond cut transaction to update everything at once. This results in less transactions and lays the groundwork for multisig approach where the diamond cut transaction can be exported and carried out by a multisig.

It also has two other benefits:
1. Updating the contracts is simpler `make redeploy-Allfacets rpc="chain-name"` so we won't need to write custom scripts for each update on inexpensive chains. Can be improved to run for a single facet in the future.
2. We can use this script in integration tests making the setup less verbose and more uniform, reducing chance for errors (to be refactored in the future)
